### PR TITLE
Migrate OAuth token storage to flutter_secure_storage

### DIFF
--- a/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -56,6 +56,11 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin flutter_plugin_android_lifecycle, io.flutter.plugins.flutter_plugin_android_lifecycle.FlutterAndroidLifecyclePlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin flutter_secure_storage, com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new net.wolverinebeach.flutter_timezone.FlutterTimezonePlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin flutter_timezone, net.wolverinebeach.flutter_timezone.FlutterTimezonePlugin", e);

--- a/lib/ui/parts/flutter_brand_icons.dart
+++ b/lib/ui/parts/flutter_brand_icons.dart
@@ -1,12 +1,8 @@
 import "package:flutter/widgets.dart";
 
-class BrandIconData extends IconData {
-  const BrandIconData(super.codePoint) : super(fontFamily: "brands");
-}
-
 class BrandIcons {
-  static const IconData fitbit = BrandIconData(0xe9c7);
-  static const IconData flutter = BrandIconData(0xe9cc);
-  static const IconData garmin = BrandIconData(0xe9d4);
-  static const IconData strava = BrandIconData(0xeb20);
+  static const IconData fitbit = IconData(0xe9c7, fontFamily: "brands");
+  static const IconData flutter = IconData(0xe9cc, fontFamily: "brands");
+  static const IconData garmin = IconData(0xe9d4, fontFamily: "brands");
+  static const IconData strava = IconData(0xeb20, fontFamily: "brands");
 }

--- a/lib/ui/preferences/integrations.dart
+++ b/lib/ui/preferences/integrations.dart
@@ -32,8 +32,16 @@ class IntegrationPreferencesScreenState extends State<IntegrationPreferencesScre
   void initState() {
     super.initState();
     _largerTextStyle = Get.textTheme.headlineMedium!;
+    _loadIntegrationStates();
+  }
+
+  Future<void> _loadIntegrationStates() async {
     for (final portalName in portalNames) {
-      integrationStates[portalName] = UploadService.isIntegrationEnabled(portalName);
+      final isEnabled = await UploadService.isIntegrationEnabled(portalName);
+      if (!mounted) return;
+      setState(() {
+        integrationStates[portalName] = isEnabled;
+      });
     }
   }
 
@@ -45,7 +53,7 @@ class IntegrationPreferencesScreenState extends State<IntegrationPreferencesScre
 
     UploadService uploadService = UploadService.getInstance(portalName);
     var success = false;
-    if (UploadService.isIntegrationEnabled(portalName)) {
+    if (await UploadService.isIntegrationEnabled(portalName)) {
       final returnCode = await uploadService.logout();
       debugPrint("Logout (deauthorization) return code: $returnCode");
       if (returnCode >= 200 && returnCode < 300) {
@@ -65,9 +73,12 @@ class IntegrationPreferencesScreenState extends State<IntegrationPreferencesScre
     }
 
     if (success) {
-      setState(() {
-        integrationStates[portalName] = UploadService.isIntegrationEnabled(portalName);
-      });
+      final isEnabled = await UploadService.isIntegrationEnabled(portalName);
+      if (mounted) {
+        setState(() {
+          integrationStates[portalName] = isEnabled;
+        });
+      }
     }
 
     return success;

--- a/lib/ui/preferences/preferences_hub.dart
+++ b/lib/ui/preferences/preferences_hub.dart
@@ -29,6 +29,7 @@ class PreferencesHubScreen extends StatefulWidget {
 class PreferencesHubScreenState extends State<PreferencesHubScreen> {
   double _sizeDefault = 10.0;
   TextStyle _textStyle = const TextStyle();
+  Map<String, bool> _integrationStates = {};
 
   @override
   void initState() {
@@ -38,6 +39,18 @@ class PreferencesHubScreenState extends State<PreferencesHubScreen> {
     if (!Get.isRegistered<SoundService>()) {
       Get.put<SoundService>(SoundService(), permanent: true);
     }
+    _loadIntegrationStates();
+  }
+
+  Future<void> _loadIntegrationStates() async {
+    final states = <String, bool>{};
+    for (final portalName in portalNames) {
+      states[portalName] = await UploadService.isIntegrationEnabled(portalName);
+    }
+    if (!mounted) return;
+    setState(() {
+      _integrationStates = states;
+    });
   }
 
   @override
@@ -45,7 +58,7 @@ class PreferencesHubScreenState extends State<PreferencesHubScreen> {
     final keyPart = portalNames
         .asMap()
         .entries
-        .map((e) => UploadService.isIntegrationEnabled(e.value) ? "1" : "0")
+        .map((e) => (_integrationStates[e.value] ?? false) ? "1" : "0")
         .toList()
         .join("_");
     final integrationsKey = "integrations$keyPart";

--- a/lib/upload/secure_token_storage.dart
+++ b/lib/upload/secure_token_storage.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get/get.dart';
+import 'package:pref/pref.dart';
+
+/// Thin wrapper around [FlutterSecureStorage] used by the fitness portal
+/// OAuth integrations (Strava, Suunto, Training Peaks, Under Armour) to
+/// persist access/refresh tokens, expiry timestamps, and granted scopes.
+///
+/// These values used to be stored, unencrypted, in the `pref` package
+/// (backed by `shared_preferences`). To avoid silently logging out
+/// existing installs when this class is introduced, [read] transparently
+/// migrates a value still sitting in that legacy store the first time it
+/// is looked up: if nothing has been written to secure storage yet for a
+/// given key, but the old key still holds a value, that value is copied
+/// into secure storage and removed from the legacy store before being
+/// returned to the caller. Callers do not need to know this is happening.
+class SecureTokenStorage {
+  SecureTokenStorage({FlutterSecureStorage? secureStorage})
+    : _secureStorage = secureStorage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _secureStorage;
+
+  /// Read the value stored under [key].
+  ///
+  /// Checks secure storage first. If it is empty, falls back to the
+  /// legacy `pref`/`shared_preferences` value (if any), migrating it into
+  /// secure storage and deleting the legacy entry. Returns `null` if no
+  /// value is found in either store.
+  Future<String?> read(String key) async {
+    final secureValue = await _secureStorage.read(key: key);
+    if (secureValue != null && secureValue.isNotEmpty) {
+      return secureValue;
+    }
+
+    final prefService = Get.find<BasePrefService>();
+    final legacyValue = prefService.get<dynamic>(key);
+    if (legacyValue != null && legacyValue.toString().isNotEmpty) {
+      final migratedValue = legacyValue.toString();
+      await _secureStorage.write(key: key, value: migratedValue);
+      await prefService.remove(key);
+      return migratedValue;
+    }
+
+    return null;
+  }
+
+  /// Write [value] for [key] into secure storage.
+  Future<void> write(String key, String value) => _secureStorage.write(key: key, value: value);
+
+  /// Delete the value for [key] from secure storage.
+  Future<void> delete(String key) => _secureStorage.delete(key: key);
+}

--- a/lib/upload/secure_token_storage.dart
+++ b/lib/upload/secure_token_storage.dart
@@ -22,14 +22,20 @@ class SecureTokenStorage {
 
   /// Read the value stored under [key].
   ///
-  /// Checks secure storage first. If it is empty, falls back to the
-  /// legacy `pref`/`shared_preferences` value (if any), migrating it into
-  /// secure storage and deleting the legacy entry. Returns `null` if no
-  /// value is found in either store.
+  /// Checks secure storage first, treating any stored value - including an
+  /// empty string, which callers use as a "cleared" sentinel - as
+  /// authoritative. Only when nothing has been written to secure storage yet
+  /// does this fall back to the legacy `pref`/`shared_preferences` value (if
+  /// any), migrating it into secure storage and deleting the legacy entry.
+  /// Returns `null` if no value is found in either store.
   Future<String?> read(String key) async {
     final secureValue = await _secureStorage.read(key: key);
-    if (secureValue != null && secureValue.isNotEmpty) {
+    if (secureValue != null) {
       return secureValue;
+    }
+
+    if (!Get.isRegistered<BasePrefService>()) {
+      return null;
     }
 
     final prefService = Get.find<BasePrefService>();

--- a/lib/upload/strava/oauth.dart
+++ b/lib/upload/strava/oauth.dart
@@ -6,11 +6,11 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
-import 'package:pref/pref.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../utils/constants.dart';
+import '../secure_token_storage.dart';
 import 'constants.dart';
 import 'fault.dart';
 import 'strava_status_code.dart';
@@ -21,6 +21,7 @@ import 'strava_token.dart';
 ///===========================================
 mixin Auth {
   StreamController<String> onCodeReceived = StreamController<String>.broadcast();
+  final SecureTokenStorage _secureTokenStorage = SecureTokenStorage();
 
   Future<void> registerToken(
     String? token,
@@ -51,11 +52,13 @@ mixin Auth {
 
   /// Save the token and the expiry date
   Future<void> _saveToken(String? token, String? refreshToken, int? expire, String? scope) async {
-    final prefService = Get.find<BasePrefService>();
-    await prefService.set<String>(stravaAccessTokenTag, token ?? '');
-    await prefService.set<String>(stravaRefreshTokenTag, refreshToken ?? '');
-    await prefService.set<int>(stravaExpiresAtTag, expire ?? 0); // Stored in seconds
-    await prefService.set<String>(stravaTokenScopeTag, scope ?? '');
+    await _secureTokenStorage.write(stravaAccessTokenTag, token ?? '');
+    await _secureTokenStorage.write(stravaRefreshTokenTag, refreshToken ?? '');
+    await _secureTokenStorage.write(
+      stravaExpiresAtTag,
+      (expire ?? 0).toString(),
+    ); // Stored in seconds
+    await _secureTokenStorage.write(stravaTokenScopeTag, scope ?? '');
     await registerToken(token, refreshToken, expire, scope);
     debugPrint('token saved!!!');
   }
@@ -70,11 +73,10 @@ mixin Auth {
     debugPrint('Entering _getStoredToken');
 
     try {
-      final prefService = Get.find<BasePrefService>();
-      localToken.accessToken = prefService.get<String>(stravaAccessTokenTag);
-      localToken.refreshToken = prefService.get<String>(stravaRefreshTokenTag);
-      localToken.expiresAt = prefService.get<int>(stravaExpiresAtTag);
-      localToken.scope = prefService.get<String>(stravaTokenScopeTag);
+      localToken.accessToken = await _secureTokenStorage.read(stravaAccessTokenTag);
+      localToken.refreshToken = await _secureTokenStorage.read(stravaRefreshTokenTag);
+      localToken.expiresAt = int.tryParse(await _secureTokenStorage.read(stravaExpiresAtTag) ?? '');
+      localToken.scope = await _secureTokenStorage.read(stravaTokenScopeTag);
 
       // load the data into Get
       await registerToken(
@@ -199,8 +201,7 @@ mixin Auth {
   }
 
   Future<bool> hasValidToken() async {
-    final prefService = Get.find<BasePrefService>();
-    String? accessToken = prefService.get<String>(stravaAccessTokenTag);
+    String? accessToken = await _secureTokenStorage.read(stravaAccessTokenTag);
     if (accessToken == null || accessToken.isEmpty || accessToken == "null") {
       return false;
     }

--- a/lib/upload/suunto/oauth.dart
+++ b/lib/upload/suunto/oauth.dart
@@ -5,11 +5,11 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
-import 'package:pref/pref.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../utils/constants.dart';
+import '../secure_token_storage.dart';
 import 'constants.dart';
 import 'suunto_token.dart';
 
@@ -18,6 +18,7 @@ import 'suunto_token.dart';
 ///===========================================
 mixin Auth {
   StreamController<String> onCodeReceived = StreamController<String>.broadcast();
+  final SecureTokenStorage _secureTokenStorage = SecureTokenStorage();
 
   Future<void> registerToken(String? token, String? refreshToken, int? expire) async {
     if (Get.isRegistered<SuuntoToken>()) {
@@ -37,10 +38,12 @@ mixin Auth {
 
   /// Save the token and the expiry date
   Future<void> _saveToken(String? token, String? refreshToken, int? expire) async {
-    final prefService = Get.find<BasePrefService>();
-    await prefService.set<String>(suuntoAccessTokenTag, token ?? '');
-    await prefService.set<String>(suuntoRefreshTokenTag, refreshToken ?? '');
-    await prefService.set<int>(suuntoExpiresAtTag, expire ?? 0); // Stored in seconds
+    await _secureTokenStorage.write(suuntoAccessTokenTag, token ?? '');
+    await _secureTokenStorage.write(suuntoRefreshTokenTag, refreshToken ?? '');
+    await _secureTokenStorage.write(
+      suuntoExpiresAtTag,
+      (expire ?? 0).toString(),
+    ); // Stored in seconds
     await registerToken(token, refreshToken, expire);
     debugPrint('token saved!!!');
   }
@@ -55,11 +58,10 @@ mixin Auth {
     debugPrint('Entering _getStoredToken');
 
     try {
-      final prefService = Get.find<BasePrefService>();
-      localToken.accessToken = prefService.get<String>(suuntoAccessTokenTag);
-      localToken.refreshToken = prefService.get<String>(suuntoRefreshTokenTag);
+      localToken.accessToken = await _secureTokenStorage.read(suuntoAccessTokenTag);
+      localToken.refreshToken = await _secureTokenStorage.read(suuntoRefreshTokenTag);
       // localToken.expiresAt = prefService.get<int>('expire') * 1000; // To get in ms
-      localToken.expiresAt = prefService.get<int>(suuntoExpiresAtTag);
+      localToken.expiresAt = int.tryParse(await _secureTokenStorage.read(suuntoExpiresAtTag) ?? '');
 
       // load the data into Get
       await registerToken(localToken.accessToken, localToken.refreshToken, localToken.expiresAt);
@@ -134,8 +136,7 @@ mixin Auth {
   }
 
   Future<bool> hasValidToken() async {
-    final prefService = Get.find<BasePrefService>();
-    String? accessToken = prefService.get<String>(suuntoAccessTokenTag);
+    String? accessToken = await _secureTokenStorage.read(suuntoAccessTokenTag);
     if (accessToken == null || accessToken.isEmpty) {
       return false;
     }

--- a/lib/upload/training_peaks/oauth.dart
+++ b/lib/upload/training_peaks/oauth.dart
@@ -5,11 +5,11 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
-import 'package:pref/pref.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../utils/constants.dart';
+import '../secure_token_storage.dart';
 import 'constants.dart';
 import 'training_peaks_token.dart';
 
@@ -18,6 +18,7 @@ import 'training_peaks_token.dart';
 ///===========================================
 mixin Auth {
   StreamController<String> onCodeReceived = StreamController<String>.broadcast();
+  final SecureTokenStorage _secureTokenStorage = SecureTokenStorage();
 
   String getUrlBase(bool oAuthOrApi) {
     return oAuthOrApi ? tpProductionOAuthUrlBase : tpProductionApiUrlBase;
@@ -52,11 +53,13 @@ mixin Auth {
 
   /// Save the token and the expiry date
   Future<void> _saveToken(String? token, String? refreshToken, int? expire, String? scope) async {
-    final prefService = Get.find<BasePrefService>();
-    await prefService.set<String>(trainingPeaksAccessTokenTag, token ?? '');
-    await prefService.set<String>(trainingPeaksRefreshTokenTag, refreshToken ?? '');
-    await prefService.set<int>(trainingPeaksExpiresAtTag, expire ?? 0); // Stored in seconds
-    await prefService.set<String>(trainingPeaksTokenScopeTag, scope ?? '');
+    await _secureTokenStorage.write(trainingPeaksAccessTokenTag, token ?? '');
+    await _secureTokenStorage.write(trainingPeaksRefreshTokenTag, refreshToken ?? '');
+    await _secureTokenStorage.write(
+      trainingPeaksExpiresAtTag,
+      (expire ?? 0).toString(),
+    ); // Stored in seconds
+    await _secureTokenStorage.write(trainingPeaksTokenScopeTag, scope ?? '');
     await registerToken(token, refreshToken, expire, scope);
     debugPrint('token saved!!!');
   }
@@ -71,11 +74,12 @@ mixin Auth {
     debugPrint('Entering _getStoredToken');
 
     try {
-      final prefService = Get.find<BasePrefService>();
-      localToken.accessToken = prefService.get<String>(trainingPeaksAccessTokenTag);
-      localToken.refreshToken = prefService.get<String>(trainingPeaksRefreshTokenTag);
-      localToken.expiresAt = prefService.get<int>(trainingPeaksExpiresAtTag);
-      localToken.scope = prefService.get<String>(trainingPeaksTokenScopeTag);
+      localToken.accessToken = await _secureTokenStorage.read(trainingPeaksAccessTokenTag);
+      localToken.refreshToken = await _secureTokenStorage.read(trainingPeaksRefreshTokenTag);
+      localToken.expiresAt = int.tryParse(
+        await _secureTokenStorage.read(trainingPeaksExpiresAtTag) ?? '',
+      );
+      localToken.scope = await _secureTokenStorage.read(trainingPeaksTokenScopeTag);
 
       // load the data into Get
       await registerToken(
@@ -154,8 +158,7 @@ mixin Auth {
   }
 
   Future<bool> hasValidToken() async {
-    final prefService = Get.find<BasePrefService>();
-    String? accessToken = prefService.get<String>(trainingPeaksAccessTokenTag);
+    String? accessToken = await _secureTokenStorage.read(trainingPeaksAccessTokenTag);
     if (accessToken == null || accessToken.isEmpty || accessToken == "null") {
       return false;
     }

--- a/lib/upload/under_armour/oauth.dart
+++ b/lib/upload/under_armour/oauth.dart
@@ -5,11 +5,11 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:http/http.dart' as http;
-import 'package:pref/pref.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import '../../utils/constants.dart';
+import '../secure_token_storage.dart';
 import 'constants.dart';
 import 'under_armour_token.dart';
 
@@ -18,6 +18,7 @@ import 'under_armour_token.dart';
 ///===========================================
 mixin Auth {
   StreamController<String> onCodeReceived = StreamController<String>.broadcast();
+  final SecureTokenStorage _secureTokenStorage = SecureTokenStorage();
 
   Future<void> registerToken(String? token, String? refreshToken, int? expire) async {
     if (Get.isRegistered<UnderArmourToken>()) {
@@ -37,10 +38,12 @@ mixin Auth {
 
   /// Save the token and the expiry date
   Future<void> _saveToken(String? token, String? refreshToken, int? expire) async {
-    final prefService = Get.find<BasePrefService>();
-    await prefService.set<String>(underArmourAccessTokenTag, token ?? '');
-    await prefService.set<String>(underArmourRefreshTokenTag, refreshToken ?? '');
-    await prefService.set<int>(underArmourExpiresAtTag, expire ?? 0); // Stored in seconds
+    await _secureTokenStorage.write(underArmourAccessTokenTag, token ?? '');
+    await _secureTokenStorage.write(underArmourRefreshTokenTag, refreshToken ?? '');
+    await _secureTokenStorage.write(
+      underArmourExpiresAtTag,
+      (expire ?? 0).toString(),
+    ); // Stored in seconds
     await registerToken(token, refreshToken, expire);
     debugPrint('token saved!!!');
   }
@@ -55,10 +58,11 @@ mixin Auth {
     debugPrint('Entering _getStoredToken');
 
     try {
-      final prefService = Get.find<BasePrefService>();
-      localToken.accessToken = prefService.get<String>(underArmourAccessTokenTag);
-      localToken.refreshToken = prefService.get<String>(underArmourRefreshTokenTag);
-      localToken.expiresAt = prefService.get<int>(underArmourExpiresAtTag);
+      localToken.accessToken = await _secureTokenStorage.read(underArmourAccessTokenTag);
+      localToken.refreshToken = await _secureTokenStorage.read(underArmourRefreshTokenTag);
+      localToken.expiresAt = int.tryParse(
+        await _secureTokenStorage.read(underArmourExpiresAtTag) ?? '',
+      );
 
       // load the data into Get
       await registerToken(localToken.accessToken, localToken.refreshToken, localToken.expiresAt);
@@ -130,8 +134,7 @@ mixin Auth {
   }
 
   Future<bool> hasValidToken() async {
-    final prefService = Get.find<BasePrefService>();
-    String? accessToken = prefService.get<String>(underArmourAccessTokenTag);
+    String? accessToken = await _secureTokenStorage.read(underArmourAccessTokenTag);
     if (accessToken == null || accessToken.isEmpty || accessToken == "null") {
       return false;
     }

--- a/lib/upload/upload_service.dart
+++ b/lib/upload/upload_service.dart
@@ -1,15 +1,10 @@
 import 'package:get/get.dart';
-import 'package:pref/pref.dart';
 
 import '../persistence/activity.dart';
 import 'constants.dart';
-import 'strava/constants.dart';
 import 'strava/strava_service.dart';
-import 'suunto/constants.dart';
 import 'suunto/suunto_service.dart';
-import 'training_peaks/constants.dart';
 import 'training_peaks/training_peaks_service.dart';
-import 'under_armour/constants.dart';
 import 'under_armour/under_armour_service.dart';
 
 abstract class UploadService {
@@ -51,26 +46,14 @@ abstract class UploadService {
     }
   }
 
-  static bool isIntegrationEnabled(String portalType) {
-    final prefService = Get.find<BasePrefService>();
-    switch (portalType) {
-      case suuntoChoice:
-        {
-          return prefService.get<String>(suuntoAccessTokenTag)?.isNotEmpty ?? false;
-        }
-      case underArmourChoice:
-        {
-          return prefService.get<String>(underArmourAccessTokenTag)?.isNotEmpty ?? false;
-        }
-      case trainingPeaksChoice:
-        {
-          return prefService.get<String>(trainingPeaksAccessTokenTag)?.isNotEmpty ?? false;
-        }
-      case stravaChoice:
-      default:
-        {
-          return prefService.get<String>(stravaAccessTokenTag)?.isNotEmpty ?? false;
-        }
-    }
+  /// Whether [portalType] currently has a usable (non-empty) access token.
+  ///
+  /// Delegates to the portal's own [hasValidToken], which reads from the
+  /// [SecureTokenStorage]-backed store (transparently migrating any value
+  /// still sitting in the legacy `pref`/`shared_preferences` store). This
+  /// must stay async since secure storage access is inherently async - do
+  /// not reintroduce a synchronous legacy-only read here.
+  static Future<bool> isIntegrationEnabled(String portalType) {
+    return getInstance(portalType).hasValidToken();
   }
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,10 +12,10 @@ import device_info_plus
 import file_picker
 import flutter_archive
 import flutter_blue_plus_darwin
+import flutter_secure_storage_macos
 import flutter_timezone
 import isar_community_flutter_libs
 import package_info_plus
-import path_provider_foundation
 import share_plus
 import shared_preferences_foundation
 import url_launcher_macos
@@ -29,10 +29,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterArchivePlugin.register(with: registry.registrar(forPlugin: "FlutterArchivePlugin"))
   FlutterBluePlusPlugin.register(with: registry.registrar(forPlugin: "FlutterBluePlusPlugin"))
+  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   IsarFlutterLibsPlugin.register(with: registry.registrar(forPlugin: "IsarFlutterLibsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -539,6 +539,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.34"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_spinbox:
     dependency: "direct main"
     description:
@@ -723,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -819,10 +867,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1336,10 +1384,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   heart_rate_flutter: ^0.0.3
   flutter_circle_color_picker: ^0.3.0
   flutter_layout_grid: ^2.0.8
+  flutter_secure_storage: ^9.2.4
   flutter_spinbox: ^0.13.1
   flutter_svg: ^2.2.4
   flutter_timezone: ^5.0.2

--- a/test/upload/secure_token_storage_test.dart
+++ b/test/upload/secure_token_storage_test.dart
@@ -76,6 +76,23 @@ void main() {
     },
   );
 
+  test('read treats an empty secure storage value as a cleared token and does not '
+      'migrate a stale legacy value back in', () async {
+    when(() => mockSecureStorage.read(key: testKey)).thenAnswer((_) async => '');
+
+    final result = await secureTokenStorage.read(testKey);
+
+    expect(result, '');
+    verifyNever(() => mockPrefService.get<dynamic>(any()));
+    verifyNever(
+      () => mockSecureStorage.write(
+        key: any(named: 'key'),
+        value: any(named: 'value'),
+      ),
+    );
+    verifyNever(() => mockPrefService.remove(any()));
+  });
+
   test('write stores the value in secure storage only', () async {
     when(() => mockSecureStorage.write(key: testKey, value: 'new-value')).thenAnswer((_) async {});
 

--- a/test/upload/secure_token_storage_test.dart
+++ b/test/upload/secure_token_storage_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:pref/pref.dart';
+import 'package:track_my_indoor_exercise/upload/secure_token_storage.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class MockBasePrefService extends Mock implements BasePrefService {
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) => super.toString();
+}
+
+void main() {
+  late MockFlutterSecureStorage mockSecureStorage;
+  late MockBasePrefService mockPrefService;
+  late SecureTokenStorage secureTokenStorage;
+
+  const testKey = 'testTokenTag';
+
+  setUp(() {
+    mockSecureStorage = MockFlutterSecureStorage();
+    mockPrefService = MockBasePrefService();
+    Get.put<BasePrefService>(mockPrefService, permanent: true);
+    secureTokenStorage = SecureTokenStorage(secureStorage: mockSecureStorage);
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  test('read migrates a legacy value into secure storage and deletes the legacy key '
+      'when secure storage is empty', () async {
+    when(() => mockSecureStorage.read(key: testKey)).thenAnswer((_) async => null);
+    when(() => mockPrefService.get<dynamic>(testKey)).thenReturn('legacy-access-token');
+    when(
+      () => mockSecureStorage.write(key: testKey, value: 'legacy-access-token'),
+    ).thenAnswer((_) async {});
+    when(() => mockPrefService.remove(testKey)).thenAnswer((_) async => true);
+
+    final result = await secureTokenStorage.read(testKey);
+
+    expect(result, 'legacy-access-token');
+    verify(() => mockSecureStorage.write(key: testKey, value: 'legacy-access-token')).called(1);
+    verify(() => mockPrefService.remove(testKey)).called(1);
+  });
+
+  test('read returns null when neither secure storage nor the legacy store has a value', () async {
+    when(() => mockSecureStorage.read(key: testKey)).thenAnswer((_) async => null);
+    when(() => mockPrefService.get<dynamic>(testKey)).thenReturn(null);
+
+    final result = await secureTokenStorage.read(testKey);
+
+    expect(result, isNull);
+    verifyNever(
+      () => mockSecureStorage.write(
+        key: any(named: 'key'),
+        value: any(named: 'value'),
+      ),
+    );
+    verifyNever(() => mockPrefService.remove(any()));
+  });
+
+  test(
+    'read returns the secure storage value directly without touching the legacy store',
+    () async {
+      when(() => mockSecureStorage.read(key: testKey)).thenAnswer((_) async => 'secure-value');
+
+      final result = await secureTokenStorage.read(testKey);
+
+      expect(result, 'secure-value');
+      verifyNever(() => mockPrefService.get<dynamic>(any()));
+      verifyNever(() => mockPrefService.remove(any()));
+    },
+  );
+
+  test('write stores the value in secure storage only', () async {
+    when(() => mockSecureStorage.write(key: testKey, value: 'new-value')).thenAnswer((_) async {});
+
+    await secureTokenStorage.write(testKey, 'new-value');
+
+    verify(() => mockSecureStorage.write(key: testKey, value: 'new-value')).called(1);
+    verifyNever(() => mockPrefService.get<dynamic>(any()));
+    verifyZeroInteractions(mockPrefService);
+  });
+
+  test('delete removes the value from secure storage', () async {
+    when(() => mockSecureStorage.delete(key: testKey)).thenAnswer((_) async {});
+
+    await secureTokenStorage.delete(testKey);
+
+    verify(() => mockSecureStorage.delete(key: testKey)).called(1);
+  });
+}


### PR DESCRIPTION
Access/refresh tokens, expiry timestamps, and scopes for Strava, Suunto, Training Peaks, and Under Armour were persisted unencrypted via the `pref`/`shared_preferences` backend. Add a small SecureTokenStorage helper wrapping flutter_secure_storage and route each provider's oauth.dart read/write call sites through it, keyed by the same tag strings as before.

SecureTokenStorage.read() transparently migrates any value still held in the legacy pref store on first access (copy to secure storage, then delete the legacy key), so existing installs stay logged in to their connected portals after the update. Other, non-token preferences are left untouched.