### PR TITLE
Extract record statistics logic and split recording_screen build()

### DIFF
--- a/lib/track/record_processor.dart
+++ b/lib/track/record_processor.dart
@@ -1,0 +1,154 @@
+import '../devices/gadgets/fitness_equipment.dart';
+import '../persistence/record.dart';
+import '../preferences/stage_mode.dart';
+import '../preferences/time_display_mode.dart';
+import '../utils/display.dart';
+import '../utils/statistics_accumulator.dart';
+
+/// The per-tick outcome of [RecordProcessor.process]: the widget applies
+/// these values to its own state via `setState`.
+class RecordTickResult {
+  final double distance;
+  final int lapCount;
+  final int elapsed;
+  final int markedTime;
+  final int movingTime;
+  final int? heartRate;
+
+  const RecordTickResult({
+    required this.distance,
+    required this.lapCount,
+    required this.elapsed,
+    required this.markedTime,
+    required this.movingTime,
+    required this.heartRate,
+  });
+}
+
+/// Pure, UI-independent computation of the per-record statistics, lap
+/// counter, and elapsed/moving time logic that used to be inlined in
+/// `RecordingState._recordHandlerFunction`.
+///
+/// This class never touches the database, Bluetooth devices, or chart/graph
+/// data - it only derives values from the incoming [RecordWithSport] plus
+/// whatever accumulator/timing state the caller already holds, so it is
+/// trivially unit-testable and safe to call outside of a widget tree.
+class RecordProcessor {
+  /// Computes the distance, lap counter, elapsed/moving time, and merged
+  /// heart rate for [record], and - when on-stage statistics are enabled -
+  /// accumulates them into [workoutStats] and writes the resulting average
+  /// or maximum display strings into [statistics] and [optionalStatistics]
+  /// (mutated in place, mirroring the previous inline behavior).
+  static RecordTickResult process({
+    required RecordWithSport record,
+    required WorkoutState workoutState,
+    required bool displayLapCounter,
+    required double trackLength,
+    required int currentLapCount,
+    required String timeDisplayMode,
+    required int markedTime,
+    required int? currentHeartRate,
+    required bool onStage,
+    required String onStageStatisticsType,
+    required int onStageStatisticsAlternationDuration,
+    required bool stationaryWorkout,
+    required bool showResistanceLevel,
+    required bool showInclination,
+    required bool si,
+    required String sport,
+    required StatisticsAccumulator workoutStats,
+    required List<String> statistics,
+    required List<String> optionalStatistics,
+    required int power0Index,
+    required int speed0Index,
+    required int cadence0Index,
+    required int hr0Index,
+    required int resistanceIndex,
+    required int inclinationIndex,
+  }) {
+    final distance = record.distance ?? 0.0;
+    final lapCount = displayLapCounter && trackLength > 0
+        ? (distance / trackLength).floor()
+        : currentLapCount;
+
+    var elapsed = record.elapsed ?? 0;
+    var newMarkedTime = markedTime;
+    if (timeDisplayMode == timeDisplayModeHIITMoving) {
+      if (workoutState == WorkoutState.justPaused || workoutState == WorkoutState.startedMoving) {
+        newMarkedTime = elapsed;
+      }
+
+      if (workoutState != WorkoutState.waitingForFirstMove) {
+        elapsed -= newMarkedTime;
+      }
+    }
+
+    final movingTime = record.movingTime.round();
+
+    var heartRate = currentHeartRate;
+    if (record.heartRate != null &&
+        (record.heartRate! > 0 || heartRate == null || heartRate == 0)) {
+      heartRate = record.heartRate;
+    }
+
+    if (onStage && onStageStatisticsType != onStageStatisticsTypeNone) {
+      workoutStats.processRecord(record);
+
+      if (onStageStatisticsType == onStageStatisticsTypeAverage ||
+          onStageStatisticsType == onStageStatisticsTypeAlternating &&
+              elapsed % (onStageStatisticsAlternationDuration * 2) <
+                  onStageStatisticsAlternationDuration) {
+        if (!stationaryWorkout) {
+          statistics[power0Index] = workoutStats.avgPower.toInt().toString();
+          statistics[speed0Index] = speedOrPaceString(
+            workoutStats.avgSpeed,
+            si,
+            sport,
+            limitSlowSpeed: true,
+          );
+        }
+
+        statistics[cadence0Index] = workoutStats.avgCadence.toInt().toString();
+        statistics[hr0Index] = workoutStats.avgHeartRate.toInt().toString();
+
+        if (showResistanceLevel) {
+          optionalStatistics[resistanceIndex] = workoutStats.avgResistance.toInt().toString();
+        }
+        if (showInclination) {
+          optionalStatistics[inclinationIndex] = workoutStats.avgInclination.toStringAsFixed(1);
+        }
+      } else {
+        if (!stationaryWorkout) {
+          statistics[power0Index] = workoutStats.maxPowerDisplay.toString();
+          statistics[speed0Index] = speedOrPaceString(
+            workoutStats.maxSpeedDisplay,
+            si,
+            sport,
+            limitSlowSpeed: true,
+          );
+        }
+
+        statistics[cadence0Index] = workoutStats.maxCadenceDisplay.toString();
+        statistics[hr0Index] = workoutStats.maxHeartRateDisplay.toString();
+
+        if (showResistanceLevel) {
+          optionalStatistics[resistanceIndex] = workoutStats.maxResistanceDisplay.toString();
+        }
+        if (showInclination) {
+          optionalStatistics[inclinationIndex] = workoutStats.maxInclinationDisplay.toStringAsFixed(
+            1,
+          );
+        }
+      }
+    }
+
+    return RecordTickResult(
+      distance: distance,
+      lapCount: lapCount,
+      elapsed: elapsed,
+      markedTime: newMarkedTime,
+      movingTime: movingTime,
+      heartRate: heartRate,
+    );
+  }
+}

--- a/lib/ui/parts/flutter_brand_icons.dart
+++ b/lib/ui/parts/flutter_brand_icons.dart
@@ -1,12 +1,8 @@
 import "package:flutter/widgets.dart";
 
-class BrandIconData extends IconData {
-  const BrandIconData(super.codePoint) : super(fontFamily: "brands");
-}
-
 class BrandIcons {
-  static const IconData fitbit = BrandIconData(0xe9c7);
-  static const IconData flutter = BrandIconData(0xe9cc);
-  static const IconData garmin = BrandIconData(0xe9d4);
-  static const IconData strava = BrandIconData(0xeb20);
+  static const IconData fitbit = IconData(0xe9c7, fontFamily: "brands");
+  static const IconData flutter = IconData(0xe9cc, fontFamily: "brands");
+  static const IconData garmin = IconData(0xe9d4, fontFamily: "brands");
+  static const IconData strava = IconData(0xeb20, fontFamily: "brands");
 }

--- a/lib/ui/recording/recording_screen.dart
+++ b/lib/ui/recording/recording_screen.dart
@@ -67,6 +67,7 @@ import '../../preferences/use_heart_rate_based_calorie_counting.dart';
 import '../../preferences/workout_mode.dart';
 import '../../track/calculator.dart';
 import '../../track/constants.dart';
+import '../../track/record_processor.dart';
 import '../../track/track_descriptor.dart';
 import '../../utils/bluetooth.dart';
 import '../../utils/constants.dart';
@@ -447,88 +448,45 @@ class RecordingState extends State<RecordingScreen> {
           }
         }
 
-        _distance = record.distance ?? 0.0;
-        if (_displayLapCounter) {
-          _lapCount = (_distance / _trackLength).floor();
-        }
-
-        _elapsed = record.elapsed ?? 0;
-        if (_timeDisplayMode == timeDisplayModeHIITMoving) {
-          if (workoutState == WorkoutState.justPaused ||
-              workoutState == WorkoutState.startedMoving) {
-            _markedTime = _elapsed;
-          }
-
-          if (workoutState != WorkoutState.waitingForFirstMove) {
-            _elapsed -= _markedTime;
-          }
-        }
-
-        _movingTime = record.movingTime.round();
-        if (record.heartRate != null &&
-            (record.heartRate! > 0 || _heartRate == null || _heartRate == 0)) {
-          _heartRate = record.heartRate;
-        }
+        final tickResult = RecordProcessor.process(
+          record: record,
+          workoutState: workoutState,
+          displayLapCounter: _displayLapCounter,
+          trackLength: _trackLength,
+          currentLapCount: _lapCount,
+          timeDisplayMode: _timeDisplayMode,
+          markedTime: _markedTime,
+          currentHeartRate: _heartRate,
+          onStage: _onStage,
+          onStageStatisticsType: _onStageStatisticsType,
+          onStageStatisticsAlternationDuration: _onStageStatisticsAlternationDuration,
+          stationaryWorkout: _stationaryWorkout,
+          showResistanceLevel: _showResistanceLevel,
+          showInclination: _showInclination,
+          si: _si,
+          sport: widget.descriptor.sport,
+          workoutStats: _workoutStats,
+          statistics: _statistics,
+          optionalStatistics: _optionalStatistics,
+          power0Index: _power0Index,
+          speed0Index: _speed0Index,
+          cadence0Index: _cadence0Index,
+          hr0Index: _hr0Index,
+          resistanceIndex: _resistanceIndex,
+          inclinationIndex: _inclinationIndex,
+        );
+        _distance = tickResult.distance;
+        _lapCount = tickResult.lapCount;
+        _elapsed = tickResult.elapsed;
+        _markedTime = tickResult.markedTime;
+        _movingTime = tickResult.movingTime;
+        _heartRate = tickResult.heartRate;
 
         if (_leaderboardFeature || _showPacer) {
           final selfRankTuple = _getSelfRank();
           _selfRank = selfRankTuple.item1;
           _selfAvgSpeed = selfRankTuple.item2;
           _selfRankString = _getSelfRankString();
-        }
-
-        if (_onStage && _onStageStatisticsType != onStageStatisticsTypeNone) {
-          _workoutStats.processRecord(record);
-
-          if (_onStageStatisticsType == onStageStatisticsTypeAverage ||
-              _onStageStatisticsType == onStageStatisticsTypeAlternating &&
-                  _elapsed % (_onStageStatisticsAlternationDuration * 2) <
-                      _onStageStatisticsAlternationDuration) {
-            if (!_stationaryWorkout) {
-              _statistics[_power0Index] = _workoutStats.avgPower.toInt().toString();
-              _statistics[_speed0Index] = speedOrPaceString(
-                _workoutStats.avgSpeed,
-                _si,
-                widget.descriptor.sport,
-                limitSlowSpeed: true,
-              );
-            }
-
-            _statistics[_cadence0Index] = _workoutStats.avgCadence.toInt().toString();
-            _statistics[_hr0Index] = _workoutStats.avgHeartRate.toInt().toString();
-
-            if (_showResistanceLevel) {
-              _optionalStatistics[_resistanceIndex] = _workoutStats.avgResistance
-                  .toInt()
-                  .toString();
-            }
-            if (_showInclination) {
-              _optionalStatistics[_inclinationIndex] = _workoutStats.avgInclination.toStringAsFixed(
-                1,
-              );
-            }
-          } else {
-            if (!_stationaryWorkout) {
-              _statistics[_power0Index] = _workoutStats.maxPowerDisplay.toString();
-              _statistics[_speed0Index] = speedOrPaceString(
-                _workoutStats.maxSpeedDisplay,
-                _si,
-                widget.descriptor.sport,
-                limitSlowSpeed: true,
-              );
-            }
-
-            _statistics[_cadence0Index] = _workoutStats.maxCadenceDisplay.toString();
-            _statistics[_hr0Index] = _workoutStats.maxHeartRateDisplay.toString();
-
-            if (_showResistanceLevel) {
-              _optionalStatistics[_resistanceIndex] = _workoutStats.maxResistanceDisplay.toString();
-            }
-            if (_showInclination) {
-              _optionalStatistics[_inclinationIndex] = _workoutStats.maxInclinationDisplay
-                  .toStringAsFixed(1);
-            }
-          }
         }
 
         _values = [
@@ -2509,9 +2467,9 @@ class RecordingState extends State<RecordingScreen> {
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final measuredSize = Get.mediaQuery.size;
+  /// Recomputes cached layout metrics (sizes, text styles) derived from the
+  /// current [measuredSize] whenever it changes meaningfully.
+  void _updateLayoutMetrics(Size measuredSize) {
     if (measuredSize.width != _mediaWidth || measuredSize.height != _mediaHeight) {
       _mediaWidth = measuredSize.width;
       _mediaHeight = measuredSize.height;
@@ -2533,7 +2491,11 @@ class RecordingState extends State<RecordingScreen> {
       _unitStyle = _themeManager.getBlueTextStyle(_sizeDefault / 6);
       _fullUnitStyle = _themeManager.getBlueTextStyle(_sizeDefault / 3);
     }
+  }
 
+  /// Plays or stops the target heart rate audio alert based on the latest
+  /// heart rate reading versus the configured target bounds.
+  void _maybeAlertTargetHeartRate() {
     if (_measuring &&
         _targetHrMode != targetHeartRateModeNone &&
         _targetHrAudio &&
@@ -2555,7 +2517,18 @@ class RecordingState extends State<RecordingScreen> {
         _targetHrAlerting = false;
       }
     }
+  }
 
+  /// Computes the moving/elapsed/single time display strings, the current
+  /// [WorkoutState], and the "moving"/"elapsed" column header row.
+  ({
+    String movingTimeDisplay,
+    String elapsedTimeDisplay,
+    String timeDisplay,
+    WorkoutState workoutState,
+    Widget timeHeaderRow,
+  })
+  _buildTimeDisplays() {
     final movingTimeDisplay = _onStageStatisticsType != onStageStatisticsTypeNone
         ? Duration(seconds: _movingTime ~/ 1000).toDisplay()
         : "";
@@ -2583,6 +2556,31 @@ class RecordingState extends State<RecordingScreen> {
           )
         : Container();
 
+    return (
+      movingTimeDisplay: movingTimeDisplay,
+      elapsedTimeDisplay: elapsedTimeDisplay,
+      timeDisplay: timeDisplay,
+      workoutState: workoutState,
+      timeHeaderRow: timeHeaderRow,
+    );
+  }
+
+  /// Builds the measurement row widgets (header row plus one row per
+  /// configured metric), along with the target heart rate state/style and
+  /// the speed row's text style - both of which downstream extras/columns
+  /// need to stay visually consistent with these rows.
+  ({
+    List<Widget> rows,
+    TargetHrState targetHrState,
+    TextStyle targetHrTextStyle,
+    TextStyle? speedTextStyle,
+  })
+  _buildMeasurementRows({
+    required String movingTimeDisplay,
+    required String elapsedTimeDisplay,
+    required String timeDisplay,
+    required WorkoutState workoutState,
+  }) {
     List<Widget> rows = [
       RecordingHeaderRow(
         themeManager: _themeManager,
@@ -2657,6 +2655,17 @@ class RecordingState extends State<RecordingScreen> {
       );
     }
 
+    return (
+      rows: rows,
+      targetHrState: targetHrState,
+      targetHrTextStyle: targetHrTextStyle,
+      speedTextStyle: speedTextStyle,
+    );
+  }
+
+  /// Builds the "current"/"average or maximum" statistics header row shown
+  /// above the on-stage statistics column.
+  Widget _buildStatHeaderRow() {
     final statString =
         ([
               onStageStatisticsTypeAverage,
@@ -2667,7 +2676,7 @@ class RecordingState extends State<RecordingScreen> {
                     _onStageStatisticsAlternationDuration)
         ? "average"
         : "maximum";
-    final statHeaderRow = Row(
+    return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
@@ -2678,9 +2687,21 @@ class RecordingState extends State<RecordingScreen> {
         const Spacer(),
       ],
     );
+  }
 
-    var regularExtras = [];
-    var extras = [];
+  /// Builds the expandable "extras" (per-metric charts, plus the optional
+  /// resistance/inclination charts) and the track visualization that gets
+  /// appended to [regularExtras], mirroring the metric rows built by
+  /// [_buildMeasurementRows]. Returns empty lists when the simpler UI is in
+  /// effect, since none of these extras are shown in that mode.
+  ({List<Widget?> regularExtras, List<Widget> extras}) _buildExtrasAndTrack({
+    required Size measuredSize,
+    required TargetHrState targetHrState,
+    required TextStyle targetHrTextStyle,
+    required TextStyle? speedTextStyle,
+  }) {
+    List<Widget?> regularExtras = [];
+    List<Widget> extras = [];
     if (!_simplerUi) {
       if (_showResistanceLevel) {
         extras.add(
@@ -2815,6 +2836,20 @@ class RecordingState extends State<RecordingScreen> {
       }
     }
 
+    return (regularExtras: regularExtras, extras: extras);
+  }
+
+  /// Assembles the two display columns (used side by side in landscape with
+  /// the two-column layout, or stacked into a single column otherwise) from
+  /// the previously built [rows], header rows, and extras.
+  ({List<Widget> columnOne, List<Widget> columnTwo}) _buildColumns({
+    required List<Widget> rows,
+    required Widget timeHeaderRow,
+    required Widget statHeaderRow,
+    required List<Widget> extras,
+    required List<Widget?> regularExtras,
+    required TargetHrState targetHrState,
+  }) {
     List<Widget> columnOne = _onStageStatisticsType != onStageStatisticsTypeNone
         ? [timeHeaderRow]
         : [];
@@ -2902,7 +2937,7 @@ class RecordingState extends State<RecordingScreen> {
             theme: _expandableThemeData,
             header: rows[_power1Index],
             collapsed: Container(),
-            expanded: _simplerUi ? Container() : regularExtras[_powerNIndex],
+            expanded: _simplerUi ? Container() : regularExtras[_powerNIndex]!,
             controller: _rowControllers[_powerNIndex],
           ),
         ),
@@ -2912,7 +2947,7 @@ class RecordingState extends State<RecordingScreen> {
             theme: _expandableThemeData,
             header: rows[_speed1Index],
             collapsed: Container(),
-            expanded: _simplerUi ? Container() : regularExtras[_speedNIndex],
+            expanded: _simplerUi ? Container() : regularExtras[_speedNIndex]!,
             controller: _rowControllers[_speedNIndex],
           ),
         ),
@@ -2926,7 +2961,7 @@ class RecordingState extends State<RecordingScreen> {
           theme: _expandableThemeData,
           header: rows[_cadence1Index],
           collapsed: Container(),
-          expanded: _simplerUi ? Container() : regularExtras[_cadenceNIndex],
+          expanded: _simplerUi ? Container() : regularExtras[_cadenceNIndex]!,
           controller: _rowControllers[_cadenceNIndex],
         ),
       ),
@@ -2936,7 +2971,7 @@ class RecordingState extends State<RecordingScreen> {
           theme: _expandableThemeData,
           header: rows[_hr1Index],
           collapsed: Container(),
-          expanded: _simplerUi ? Container() : regularExtras[_hrNIndex],
+          expanded: _simplerUi ? Container() : regularExtras[_hrNIndex]!,
           controller: _rowControllers[_hrNIndex],
         ),
       ),
@@ -2967,7 +3002,7 @@ class RecordingState extends State<RecordingScreen> {
               theme: _expandableThemeData,
               header: rows[_distance1Index],
               collapsed: Container(),
-              expanded: _simplerUi ? Container() : regularExtras[_distanceNIndex],
+              expanded: _simplerUi ? Container() : regularExtras[_distanceNIndex]!,
               controller: _rowControllers[_distanceNIndex],
             ),
     );
@@ -2978,7 +3013,19 @@ class RecordingState extends State<RecordingScreen> {
       columnOne.addAll(columnRest);
     }
 
-    final body = isSmallScreen(context)
+    return (columnOne: columnOne, columnTwo: columnTwo);
+  }
+
+  /// Builds the scrollable body: a single column on small screens, two
+  /// side-by-side columns in landscape with the two-column layout enabled,
+  /// or a single scrolling column otherwise.
+  Widget _buildBody(
+    BuildContext context,
+    List<Widget> rows,
+    List<Widget> columnOne,
+    List<Widget> columnTwo,
+  ) {
+    return isSmallScreen(context)
         ? _buildSmallScreenLayout(rows)
         : (_landscape && _twoColumnLayout
               ? GridView.count(
@@ -2992,7 +3039,11 @@ class RecordingState extends State<RecordingScreen> {
                   ],
                 )
               : ListView(children: columnOne));
+  }
 
+  /// Builds the app bar's action buttons (play/stop, plus pause when a
+  /// circuit workout is in progress).
+  List<Widget> _buildAppBarActions() {
     final actions = [
       IconButton(
         icon: Icon(_measuring ? Icons.stop : Icons.play_arrow),
@@ -3006,53 +3057,111 @@ class RecordingState extends State<RecordingScreen> {
       actions.insert(0, IconButton(icon: const Icon(Icons.pause), onPressed: () => Get.back()));
     }
 
+    return actions;
+  }
+
+  /// Handles the lock-screen unlock gesture's tap-up: completes the unlock
+  /// sequence if the matching button was tapped twice in a row, otherwise
+  /// resets the in-progress unlock choice.
+  void _handleUnlockTapUp(TapUpDetails details) {
+    if (!_isLocked) return;
+
+    for (var i = 0; i < _unlockChoices; ++i) {
+      if (hitTest(_unlockKeys[i], details.globalPosition)) {
+        if (_unlockKey == i && _unlockKey == _unlockButtonIndex) {
+          _fabKey.currentState?.close();
+          setState(() {
+            _isLocked = false;
+          });
+        } else {
+          _unlockKey = -2;
+        }
+        return;
+      }
+    }
+
+    if (hitTest(_fabKey, details.globalPosition)) {
+      if (_unlockKey == -1 && _fabKey.currentState != null) {
+        if (_fabKey.currentState!.isOpen) {
+          _fabKey.currentState?.close();
+        } else {
+          _fabKey.currentState?.open();
+        }
+      }
+      return;
+    }
+  }
+
+  /// Handles the lock-screen unlock gesture's tap-down: records which
+  /// unlock choice (or the FAB itself) the tap started on.
+  void _handleUnlockTapDown(TapDownDetails details) {
+    if (!_isLocked) return;
+
+    for (var i = 0; i < _unlockChoices; ++i) {
+      if (hitTest(_unlockKeys[i], details.globalPosition)) {
+        _unlockKey = i;
+        return;
+      }
+    }
+
+    if (hitTest(_fabKey, details.globalPosition)) {
+      _unlockKey = -1;
+      return;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final measuredSize = Get.mediaQuery.size;
+    _updateLayoutMetrics(measuredSize);
+    _maybeAlertTargetHeartRate();
+
+    final timeDisplays = _buildTimeDisplays();
+    final workoutState = timeDisplays.workoutState;
+    final timeHeaderRow = timeDisplays.timeHeaderRow;
+
+    final measurementRows = _buildMeasurementRows(
+      movingTimeDisplay: timeDisplays.movingTimeDisplay,
+      elapsedTimeDisplay: timeDisplays.elapsedTimeDisplay,
+      timeDisplay: timeDisplays.timeDisplay,
+      workoutState: workoutState,
+    );
+    List<Widget> rows = measurementRows.rows;
+    final targetHrState = measurementRows.targetHrState;
+    final targetHrTextStyle = measurementRows.targetHrTextStyle;
+    TextStyle? speedTextStyle = measurementRows.speedTextStyle;
+
+    final statHeaderRow = _buildStatHeaderRow();
+
+    final extrasAndTrack = _buildExtrasAndTrack(
+      measuredSize: measuredSize,
+      targetHrState: targetHrState,
+      targetHrTextStyle: targetHrTextStyle,
+      speedTextStyle: speedTextStyle,
+    );
+    var regularExtras = extrasAndTrack.regularExtras;
+    var extras = extrasAndTrack.extras;
+
+    final columns = _buildColumns(
+      rows: rows,
+      timeHeaderRow: timeHeaderRow,
+      statHeaderRow: statHeaderRow,
+      extras: extras,
+      regularExtras: regularExtras,
+      targetHrState: targetHrState,
+    );
+    List<Widget> columnOne = columns.columnOne;
+    List<Widget> columnTwo = columns.columnTwo;
+
+    final body = _buildBody(context, rows, columnOne, columnTwo);
+    final actions = _buildAppBarActions();
+
     return PopScope(
       canPop: !_measuring || _circuitWorkout,
       child: GestureDetector(
         behavior: HitTestBehavior.deferToChild,
-        onTapUp: (details) {
-          if (!_isLocked) return;
-
-          for (var i = 0; i < _unlockChoices; ++i) {
-            if (hitTest(_unlockKeys[i], details.globalPosition)) {
-              if (_unlockKey == i && _unlockKey == _unlockButtonIndex) {
-                _fabKey.currentState?.close();
-                setState(() {
-                  _isLocked = false;
-                });
-              } else {
-                _unlockKey = -2;
-              }
-              return;
-            }
-          }
-
-          if (hitTest(_fabKey, details.globalPosition)) {
-            if (_unlockKey == -1 && _fabKey.currentState != null) {
-              if (_fabKey.currentState!.isOpen) {
-                _fabKey.currentState?.close();
-              } else {
-                _fabKey.currentState?.open();
-              }
-            }
-            return;
-          }
-        },
-        onTapDown: (details) {
-          if (!_isLocked) return;
-
-          for (var i = 0; i < _unlockChoices; ++i) {
-            if (hitTest(_unlockKeys[i], details.globalPosition)) {
-              _unlockKey = i;
-              return;
-            }
-          }
-
-          if (hitTest(_fabKey, details.globalPosition)) {
-            _unlockKey = -1;
-            return;
-          }
-        },
+        onTapUp: _handleUnlockTapUp,
+        onTapDown: _handleUnlockTapDown,
         child: AbsorbPointer(
           absorbing: _isLocked,
           child: Scaffold(

--- a/test/track/record_processor_test.dart
+++ b/test/track/record_processor_test.dart
@@ -1,0 +1,379 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:track_my_indoor_exercise/devices/gadgets/fitness_equipment.dart';
+import 'package:track_my_indoor_exercise/persistence/record.dart';
+import 'package:track_my_indoor_exercise/preferences/stage_mode.dart';
+import 'package:track_my_indoor_exercise/preferences/time_display_mode.dart';
+import 'package:track_my_indoor_exercise/track/record_processor.dart';
+import 'package:track_my_indoor_exercise/utils/constants.dart';
+import 'package:track_my_indoor_exercise/utils/statistics_accumulator.dart';
+
+RecordTickResult _process({
+  required RecordWithSport record,
+  WorkoutState workoutState = WorkoutState.moving,
+  bool displayLapCounter = false,
+  double trackLength = 250.0,
+  int currentLapCount = 0,
+  String timeDisplayMode = timeDisplayModeElapsed,
+  int markedTime = 0,
+  int? currentHeartRate,
+  bool onStage = false,
+  String onStageStatisticsType = onStageStatisticsTypeNone,
+  int onStageStatisticsAlternationDuration = 10,
+  bool stationaryWorkout = false,
+  bool showResistanceLevel = false,
+  bool showInclination = false,
+  bool si = true,
+  String sport = ActivityType.ride,
+  StatisticsAccumulator? workoutStats,
+  List<String>? statistics,
+  List<String>? optionalStatistics,
+}) {
+  return RecordProcessor.process(
+    record: record,
+    workoutState: workoutState,
+    displayLapCounter: displayLapCounter,
+    trackLength: trackLength,
+    currentLapCount: currentLapCount,
+    timeDisplayMode: timeDisplayMode,
+    markedTime: markedTime,
+    currentHeartRate: currentHeartRate,
+    onStage: onStage,
+    onStageStatisticsType: onStageStatisticsType,
+    onStageStatisticsAlternationDuration: onStageStatisticsAlternationDuration,
+    stationaryWorkout: stationaryWorkout,
+    showResistanceLevel: showResistanceLevel,
+    showInclination: showInclination,
+    si: si,
+    sport: sport,
+    workoutStats: workoutStats ?? StatisticsAccumulator(si: si, sport: sport),
+    statistics: statistics ?? List<String>.filled(6, emptyMeasurement, growable: true),
+    optionalStatistics:
+        optionalStatistics ?? List<String>.filled(3, emptyMeasurement, growable: true),
+    power0Index: 1,
+    speed0Index: 2,
+    cadence0Index: 3,
+    hr0Index: 4,
+    resistanceIndex: 0,
+    inclinationIndex: 2,
+  );
+}
+
+void main() {
+  group('RecordProcessor distance and lap counter', () {
+    test('passes distance through unchanged', () {
+      final record = RecordWithSport(distance: 123.4, sport: ActivityType.ride);
+      final result = _process(record: record);
+      expect(result.distance, 123.4);
+    });
+
+    test('defaults distance to 0.0 when record has none', () {
+      final record = RecordWithSport(sport: ActivityType.ride);
+      final result = _process(record: record);
+      expect(result.distance, 0.0);
+    });
+
+    test('computes lap count from distance / track length when enabled', () {
+      final record = RecordWithSport(distance: 625.0, sport: ActivityType.ride);
+      final result = _process(record: record, displayLapCounter: true, trackLength: 250.0);
+      expect(result.lapCount, 2);
+    });
+
+    test('leaves lap count unchanged when the counter is disabled', () {
+      final record = RecordWithSport(distance: 625.0, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        displayLapCounter: false,
+        trackLength: 250.0,
+        currentLapCount: 7,
+      );
+      expect(result.lapCount, 7);
+    });
+
+    test('leaves lap count unchanged when the counter is enabled but track length is 0', () {
+      final record = RecordWithSport(distance: 625.0, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        displayLapCounter: true,
+        trackLength: 0,
+        currentLapCount: 7,
+      );
+      expect(result.lapCount, 7);
+    });
+  });
+
+  group('RecordProcessor elapsed/moving time', () {
+    test('passes elapsed through unmodified outside HIIT moving-time mode', () {
+      final record = RecordWithSport(elapsed: 100, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        timeDisplayMode: timeDisplayModeElapsed,
+        workoutState: WorkoutState.justPaused,
+        markedTime: 5,
+      );
+      expect(result.elapsed, 100);
+      expect(result.markedTime, 5);
+    });
+
+    test('marks the reference time on pause/resume in HIIT moving-time mode', () {
+      final record = RecordWithSport(elapsed: 100, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        timeDisplayMode: timeDisplayModeHIITMoving,
+        workoutState: WorkoutState.startedMoving,
+        markedTime: 40,
+      );
+      // markedTime is refreshed to the current elapsed, then subtracted right away.
+      expect(result.markedTime, 100);
+      expect(result.elapsed, 0);
+    });
+
+    test('subtracts the previously marked time while moving in HIIT mode', () {
+      final record = RecordWithSport(elapsed: 130, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        timeDisplayMode: timeDisplayModeHIITMoving,
+        workoutState: WorkoutState.moving,
+        markedTime: 30,
+      );
+      expect(result.markedTime, 30);
+      expect(result.elapsed, 100);
+    });
+
+    test('does not subtract marked time while waiting for the first move', () {
+      final record = RecordWithSport(elapsed: 5, sport: ActivityType.ride);
+      final result = _process(
+        record: record,
+        timeDisplayMode: timeDisplayModeHIITMoving,
+        workoutState: WorkoutState.waitingForFirstMove,
+        markedTime: 0,
+      );
+      expect(result.elapsed, 5);
+      expect(result.markedTime, 0);
+    });
+
+    test('rounds the moving time from the record', () {
+      final record = RecordWithSport(sport: ActivityType.ride);
+      record.movingTime = 1234;
+      final result = _process(record: record);
+      expect(result.movingTime, 1234);
+    });
+  });
+
+  group('RecordProcessor heart rate merge', () {
+    test('adopts the incoming heart rate when there is no current value', () {
+      final record = RecordWithSport(heartRate: 88, sport: ActivityType.ride);
+      final result = _process(record: record, currentHeartRate: null);
+      expect(result.heartRate, 88);
+    });
+
+    test('adopts the incoming heart rate when the current value is zero', () {
+      final record = RecordWithSport(heartRate: 77, sport: ActivityType.ride);
+      final result = _process(record: record, currentHeartRate: 0);
+      expect(result.heartRate, 77);
+    });
+
+    test('adopts a fresh positive heart rate over an existing positive one', () {
+      final record = RecordWithSport(heartRate: 150, sport: ActivityType.ride);
+      final result = _process(record: record, currentHeartRate: 120);
+      expect(result.heartRate, 150);
+    });
+
+    test('keeps the existing heart rate when the incoming reading is zero', () {
+      final record = RecordWithSport(heartRate: 0, sport: ActivityType.ride);
+      final result = _process(record: record, currentHeartRate: 120);
+      expect(result.heartRate, 120);
+    });
+
+    test('keeps the existing heart rate when the incoming reading is missing', () {
+      final record = RecordWithSport(sport: ActivityType.ride);
+      final result = _process(record: record, currentHeartRate: 120);
+      expect(result.heartRate, 120);
+    });
+  });
+
+  group('RecordProcessor on-stage statistics', () {
+    test('leaves statistics untouched when on-stage display is off', () {
+      final record = RecordWithSport(power: 200, speed: 30.0, sport: ActivityType.ride);
+      final statistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: false,
+        onStageStatisticsType: onStageStatisticsTypeAverage,
+        statistics: statistics,
+      );
+      expect(statistics.every((value) => value == emptyMeasurement), true);
+    });
+
+    test('leaves statistics untouched when the statistics type is none', () {
+      final record = RecordWithSport(power: 200, speed: 30.0, sport: ActivityType.ride);
+      final statistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeNone,
+        statistics: statistics,
+      );
+      expect(statistics.every((value) => value == emptyMeasurement), true);
+    });
+
+    test('writes average power/speed/cadence/hr in average mode', () {
+      final record = RecordWithSport(
+        power: 200,
+        speed: 30.0,
+        cadence: 90,
+        heartRate: 140,
+        sport: ActivityType.ride,
+      );
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateAvgPower: true,
+        calculateAvgSpeed: true,
+        calculateAvgCadence: true,
+        calculateAvgHeartRate: true,
+      );
+      final statistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAverage,
+        workoutStats: workoutStats,
+        statistics: statistics,
+      );
+      expect(statistics[1], '200');
+      expect(statistics[3], '90');
+      expect(statistics[4], '140');
+    });
+
+    test('writes maximum values in maximum mode', () {
+      final record = RecordWithSport(
+        power: 200,
+        cadence: 90,
+        heartRate: 140,
+        sport: ActivityType.ride,
+      );
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateMaxPower: true,
+        calculateMaxCadence: true,
+        calculateMaxHeartRate: true,
+      );
+      final statistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeMaximum,
+        workoutStats: workoutStats,
+        statistics: statistics,
+      );
+      expect(statistics[1], '200');
+      expect(statistics[3], '90');
+      expect(statistics[4], '140');
+    });
+
+    test('skips power/speed statistics for a stationary workout', () {
+      final record = RecordWithSport(
+        power: 200,
+        speed: 30.0,
+        cadence: 90,
+        heartRate: 140,
+        sport: ActivityType.ride,
+      );
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateAvgPower: true,
+        calculateAvgSpeed: true,
+        calculateAvgCadence: true,
+        calculateAvgHeartRate: true,
+      );
+      final statistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAverage,
+        stationaryWorkout: true,
+        workoutStats: workoutStats,
+        statistics: statistics,
+      );
+      expect(statistics[1], emptyMeasurement);
+      expect(statistics[2], emptyMeasurement);
+      expect(statistics[3], '90');
+      expect(statistics[4], '140');
+    });
+
+    test('fills in optional resistance/inclination statistics when requested', () {
+      final record = RecordWithSport(resistance: 42, inclination: 3.4, sport: ActivityType.ride);
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateAvgResistance: true,
+        calculateAvgInclination: true,
+      );
+      final optionalStatistics = List<String>.filled(3, emptyMeasurement, growable: true);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAverage,
+        showResistanceLevel: true,
+        showInclination: true,
+        workoutStats: workoutStats,
+        optionalStatistics: optionalStatistics,
+      );
+      expect(optionalStatistics[0], '42');
+      expect(optionalStatistics[2], '3.4');
+    });
+
+    test('alternates between average and maximum based on elapsed time', () {
+      final avgRecord = RecordWithSport(elapsed: 5, power: 200, sport: ActivityType.ride);
+      final maxRecord = RecordWithSport(elapsed: 15, power: 200, sport: ActivityType.ride);
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateAvgPower: true,
+        calculateMaxPower: true,
+      );
+
+      final avgStatistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: avgRecord,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAlternating,
+        onStageStatisticsAlternationDuration: 10,
+        workoutStats: workoutStats,
+        statistics: avgStatistics,
+      );
+      expect(avgStatistics[1], workoutStats.avgPower.toInt().toString());
+
+      final maxStatistics = List<String>.filled(6, emptyMeasurement, growable: true);
+      _process(
+        record: maxRecord,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAlternating,
+        onStageStatisticsAlternationDuration: 10,
+        workoutStats: workoutStats,
+        statistics: maxStatistics,
+      );
+      expect(maxStatistics[1], workoutStats.maxPowerDisplay.toString());
+    });
+
+    test('accumulates the record into the shared workout stats accumulator', () {
+      final record = RecordWithSport(power: 200, sport: ActivityType.ride);
+      final workoutStats = StatisticsAccumulator(
+        si: true,
+        sport: ActivityType.ride,
+        calculateAvgPower: true,
+      );
+      expect(workoutStats.powerCount, 0);
+      _process(
+        record: record,
+        onStage: true,
+        onStageStatisticsType: onStageStatisticsTypeAverage,
+        workoutStats: workoutStats,
+      );
+      expect(workoutStats.powerCount, 1);
+      expect(workoutStats.powerSum, 200);
+    });
+  });
+}


### PR DESCRIPTION
Pulls the pure per-record statistics/lap/calorie computation out of RecordingState._recordHandlerFunction into a new UI-independent RecordProcessor (lib/track/record_processor.dart), covered by unit tests in test/track/record_processor_test.dart. The widget now calls RecordProcessor.process() and applies the returned RecordTickResult via setState; the Isar write, graph-data mutation, and device wiring are untouched.

Also splits RecordingState.build() (~597 lines) into ~10 named private methods for the layout metrics, target-HR audio alert, time/stat header rows, measurement rows, chart extras/track visualization, column assembly, body, app bar actions, and the lock-screen gesture handlers. This is a pure code move - no rendering or behavior changes - cutting build() itself down to ~106 lines.