### PR TITLE
Extract domain logic from DbUtils into ActivityCalculator

### DIFF
--- a/lib/persistence/db_utils.dart
+++ b/lib/persistence/db_utils.dart
@@ -3,10 +3,9 @@ import 'package:get/get.dart';
 import 'package:isar_community/isar.dart';
 import 'package:tuple/tuple.dart';
 
-import '../devices/device_descriptors/device_descriptor.dart';
+import '../track/activity_calculator.dart';
 import '../utils/address_names.dart';
 import '../utils/constants.dart';
-import '../utils/power_speed_mixin.dart';
 import 'activity.dart';
 import 'calorie_tune.dart';
 import 'power_tune.dart';
@@ -14,8 +13,9 @@ import 'record.dart';
 import 'workout_summary.dart';
 import 'device_usage.dart';
 
-class DbUtils with PowerSpeedMixin {
+class DbUtils {
   late final Isar database;
+  final ActivityCalculator _calculator = ActivityCalculator();
 
   DbUtils() {
     database = Get.find<Isar>();
@@ -51,90 +51,13 @@ class DbUtils with PowerSpeedMixin {
       return false;
     }
 
-    if (recalculateMore) {
-      initPower2SpeedConstants();
-    }
+    await _calculator.recalculateRecords(activity, records, recalculateMore);
 
-    var previousRecord = records.first;
-    double calories = 0.0;
-    double strides = 0.0;
-    double distance = 0.0;
-    double movingTime = 0.0;
-    for (final record in records.skip(1)) {
-      final dTMillis = record.timeStamp!.difference(previousRecord.timeStamp!).inMilliseconds;
-      final dTime = dTMillis / 1000.0;
-
-      double speed = record.speed ?? 0.0;
-      int power = record.power ?? 0;
-      int cadence = record.cadence ?? 0;
-
-      bool moving = (speed > 0.0 || power > 0 || cadence > 0);
-      if (moving) {
-        movingTime += dTMillis;
-        if ((record.cadence ?? 0) <= 0 && (previousRecord.cadence ?? 0) > 0) {
-          record.cadence = previousRecord.cadence;
-        }
-
-        if ((record.cadence ?? 0) > 0) {
-          strides += (record.cadence ?? 0) * dTMillis / (60 * 1000);
-        }
-
-        if ((record.power ?? 0) <= 0 && (previousRecord.power ?? 0) > 0) {
-          record.power = previousRecord.power;
-        }
-
-        if (record.power != null &&
-            record.power! > 0.0 &&
-            recalculateMore &&
-            activity.sport == ActivityType.ride) {
-          record.speed = velocityForPowerCardano(record.power!) * DeviceDescriptor.ms2kmh;
-        }
-
-        if ((record.speed ?? 0.0) <= eps && (previousRecord.speed ?? 0.0) > eps) {
-          record.speed = previousRecord.speed;
-        }
-      }
-
-      if ((record.heartRate ?? 0) <= 0 && (previousRecord.heartRate ?? 0) > 0) {
-        record.heartRate = previousRecord.heartRate;
-      }
-
-      record.elapsed = movingTime ~/ 1000;
-
-      // Recalculate distance
-      double dDistance = speed * DeviceDescriptor.kmh2ms * dTime;
-      distance += dDistance;
-      record.distance = distance;
-
-      // Recalculate calories
-      double dCal =
-          power *
-          dTime *
-          jToCal *
-          activity.calorieFactor *
-          DeviceDescriptor.powerCalorieFactorDefault;
-      calories += dCal;
-      record.calories = calories ~/ 1000;
-
-      database.writeTxnSync(() {
+    database.writeTxnSync(() {
+      for (final record in records.skip(1)) {
         database.records.putSync(record);
-      });
-
-      previousRecord = record;
-    }
-
-    activity.distance = previousRecord.distance!;
-    activity.calories = previousRecord.calories!;
-    if (strides.toInt() > activity.strides || activity.strides > movingTime / 1000 / 60 * 180) {
-      activity.strides = strides.toInt();
-    }
-
-    if (activity.end == null || activity.end!.compareTo(previousRecord.timeStamp!) <= 0) {
-      activity.end = previousRecord.timeStamp;
-    }
-
-    activity.elapsed = activity.end!.difference(activity.start).inSeconds;
-    activity.movingTime = movingTime.toInt();
+      }
+    });
 
     updateActivity(activity);
 
@@ -147,36 +70,13 @@ class DbUtils with PowerSpeedMixin {
       return false;
     }
 
-    var previousRecord = records.first;
-    for (final record in records.skip(1)) {
-      bool modified = false;
-      if ((record.cadence ?? 0) <= 0 && (previousRecord.cadence ?? 0) > 0) {
-        record.cadence = previousRecord.cadence;
-        modified = true;
-      }
-
-      if ((record.power ?? 0) <= 0 && (previousRecord.power ?? 0) > 0) {
-        record.power = previousRecord.power;
-        modified = true;
-      }
-
-      if ((record.speed ?? 0.0) <= eps && (previousRecord.speed ?? 0.0) > eps) {
-        record.speed = previousRecord.speed;
-        modified = true;
-      }
-
-      if ((record.heartRate ?? 0) <= 0 && (previousRecord.heartRate ?? 0) > 0) {
-        record.heartRate = previousRecord.heartRate;
-        modified = true;
-      }
-
-      if (modified) {
-        database.writeTxnSync(() {
+    final modifiedRecords = _calculator.bridgeDataGaps(records);
+    if (modifiedRecords.isNotEmpty) {
+      database.writeTxnSync(() {
+        for (final record in modifiedRecords) {
           database.records.putSync(record);
-        });
-      }
-
-      previousRecord = record;
+        }
+      });
     }
 
     return true;
@@ -203,7 +103,7 @@ class DbUtils with PowerSpeedMixin {
         .macEqualTo(deviceId)
         .sortByTimeDesc()
         .findFirst();
-    return powerTune?.powerFactor ?? 1.0;
+    return _calculator.powerFactorFromTune(powerTune);
   }
 
   Future<CalorieTune?> findCalorieTuneByMac(String mac, bool hrBased) async {
@@ -218,7 +118,7 @@ class DbUtils with PowerSpeedMixin {
 
   Future<double> calorieFactorValue(String deviceId, bool hrBased) async {
     final calorieTune = await findCalorieTuneByMac(deviceId, hrBased);
-    return calorieTune?.calorieFactor ?? 1.0;
+    return _calculator.calorieFactorFromTune(calorieTune);
   }
 
   Future<Tuple3<double, double, double>> getFactors(String deviceId) async {
@@ -235,34 +135,7 @@ class DbUtils with PowerSpeedMixin {
       return false;
     }
 
-    int updated = 0;
-    if (lastRecord.calories != null && lastRecord.calories! > 0 && activity.calories == 0) {
-      activity.calories = lastRecord.calories!;
-      updated++;
-    }
-
-    if (lastRecord.distance != null && lastRecord.distance! > 0 && activity.distance == 0) {
-      activity.distance = lastRecord.distance!;
-      updated++;
-    }
-
-    if (lastRecord.timeStamp != null && activity.end != null) {
-      activity.end = lastRecord.timeStamp!;
-      updated++;
-    }
-
-    if (lastRecord.elapsed != null && lastRecord.elapsed! > 0 && activity.elapsed == 0) {
-      activity.elapsed = lastRecord.elapsed!;
-      updated++;
-    }
-
-    if (activity.elapsed == 0 && activity.end != null) {
-      final elapsedMillis = activity.end!.difference(activity.start).inMilliseconds;
-      if (elapsedMillis >= 1000) {
-        activity.elapsed = elapsedMillis ~/ 1000;
-        updated++;
-      }
-    }
+    bool updated = _calculator.applyFinalization(activity, lastRecord);
 
     if (activity.movingTime == 0 || activity.strides == 0) {
       final records = await getRecords(activity.id);
@@ -270,41 +143,14 @@ class DbUtils with PowerSpeedMixin {
         return false;
       }
 
-      double movingMillis = 0;
-      double strides = 0;
-      var previousRecord = records.first;
-      for (final record in records.skip(1)) {
-        final dTMillis = record.timeStamp!.difference(previousRecord.timeStamp!).inMilliseconds;
-        if (!record.isNotMoving()) {
-          movingMillis += dTMillis;
-        }
-
-        double strokeCount = record.strokeCount ?? 0.0;
-        if (strokeCount > eps) {
-          strides += strokeCount * dTMillis / (1000 * 60);
-        }
-
-        previousRecord = record;
-      }
-
-      if (movingMillis > eps || strides > eps) {
-        if (movingMillis > eps) {
-          activity.movingTime = movingMillis.toInt();
-        }
-
-        if (strides > eps) {
-          activity.strides = strides.toInt();
-        }
-
-        updated++;
-      }
+      updated = _calculator.applyMovingTimeAndStrides(activity, records) || updated;
     }
 
-    if (updated > 0) {
+    if (updated) {
       updateActivity(activity);
     }
 
-    return updated > 0;
+    return updated;
   }
 
   Future<void> getAddressNameDictionary(AddressNames addressNames) async {
@@ -364,11 +210,7 @@ class DbUtils with PowerSpeedMixin {
   }
 
   Future<bool> offsetActivity(Activity activity, int minutes) async {
-    final offset = Duration(minutes: minutes);
-    activity.start = activity.start.add(offset);
-    if (activity.end != null) {
-      activity.end = activity.end!.add(offset);
-    }
+    _calculator.applyTimeOffset(activity, minutes);
 
     updateActivity(activity);
 
@@ -377,10 +219,11 @@ class DbUtils with PowerSpeedMixin {
       return false;
     }
 
+    _calculator.applyRecordTimeOffset(records, minutes);
+
     database.writeTxnSync(() {
       for (final record in records) {
         if (record.timeStamp != null) {
-          record.timeStamp = record.timeStamp!.add(offset);
           database.records.putSync(record);
         }
       }
@@ -423,27 +266,23 @@ class DbUtils with PowerSpeedMixin {
       }
     }
 
-    final splitPoint = Duration(minutes: minutesSplitPoint);
     activity.start = records.first.timeStamp!;
-    final watermark = activity.start.add(splitPoint);
-    var lastRecord = records.first;
+    final plan = _calculator.computeSplitPlan(records, minutesSplitPoint);
+
     database.writeTxnSync(() {
-      bool inFirstPart = true;
-      for (final record in records) {
-        if (record.timeStamp != null && record.timeStamp!.compareTo(watermark) > 0) {
-          if (inFirstPart) {
-            activity.end = lastRecord.timeStamp;
-            target!.start = record.timeStamp!;
-          }
-          inFirstPart = false;
-          record.activityId = target!.id;
-          database.records.putSync(record);
-        }
-        lastRecord = record;
+      for (final record in plan.secondPartRecords) {
+        record.activityId = target!.id;
+        database.records.putSync(record);
       }
     });
 
-    target.end = lastRecord.timeStamp;
+    if (plan.firstPartEnd != null) {
+      activity.end = plan.firstPartEnd;
+    }
+    if (plan.secondPartStart != null) {
+      target.start = plan.secondPartStart!;
+    }
+    target.end = plan.secondPartEnd;
     // if (activity.end != null) {
     //   activity.end = activity.end!.add(-splitPoint);
     // }

--- a/lib/track/activity_calculator.dart
+++ b/lib/track/activity_calculator.dart
@@ -1,0 +1,332 @@
+import '../devices/device_descriptors/device_descriptor.dart';
+import '../persistence/activity.dart';
+import '../persistence/calorie_tune.dart';
+import '../persistence/power_tune.dart';
+import '../persistence/record.dart';
+import '../utils/constants.dart';
+import '../utils/power_speed_mixin.dart';
+
+/// The outcome of computing where an activity split falls within a list of
+/// records that are ordered by [Record.timeStamp].
+///
+/// This mirrors the exact semantics of the original in-line split logic in
+/// `DbUtils.splitActivity`: [firstPartEnd] and [secondPartStart] are only
+/// populated the first time a record crosses the split watermark (i.e. once
+/// the split has actually happened), while [secondPartEnd] always reflects
+/// the timestamp of the very last record, even when no record ends up on the
+/// far side of the split.
+class SplitPlan {
+  final DateTime? firstPartEnd;
+  final DateTime? secondPartStart;
+  final DateTime secondPartEnd;
+  final List<Record> secondPartRecords;
+
+  SplitPlan({
+    required this.firstPartEnd,
+    required this.secondPartStart,
+    required this.secondPartEnd,
+    required this.secondPartRecords,
+  });
+}
+
+/// Pure(ish) domain/business logic for activities and their records.
+///
+/// This class deliberately knows nothing about persistence: every method
+/// here operates on already-loaded [Activity] / [Record] objects (mutating
+/// them in place where that matches the previous behavior) and returns
+/// computed results. Callers (currently `DbUtils`) are responsible for
+/// loading data from and writing results back to storage.
+///
+/// The only side effect that isn't purely computational is
+/// [PowerSpeedMixin.initPower2SpeedConstants], which reads shared
+/// preferences (not the workout database) to refresh the power/speed
+/// conversion constants; it is kept here because the conversion math
+/// ([PowerSpeedMixin.velocityForPowerCardano]) that depends on it lives in
+/// the same mixin.
+class ActivityCalculator with PowerSpeedMixin {
+  /// Forward-fills gaps in [records] by copying the previous record's value
+  /// for cadence/power/speed/heart-rate whenever the current record is
+  /// missing (or zero for cadence/power/heart-rate, or near-zero for speed)
+  /// a value that the previous record had.
+  ///
+  /// Mutates the affected [Record]s in place and returns the sublist that
+  /// was actually modified, so the caller can persist only those.
+  List<Record> bridgeDataGaps(List<Record> records) {
+    if (records.isEmpty) {
+      return const [];
+    }
+
+    var previousRecord = records.first;
+    final modifiedRecords = <Record>[];
+    for (final record in records.skip(1)) {
+      bool modified = false;
+      if ((record.cadence ?? 0) <= 0 && (previousRecord.cadence ?? 0) > 0) {
+        record.cadence = previousRecord.cadence;
+        modified = true;
+      }
+
+      if ((record.power ?? 0) <= 0 && (previousRecord.power ?? 0) > 0) {
+        record.power = previousRecord.power;
+        modified = true;
+      }
+
+      if ((record.speed ?? 0.0) <= eps && (previousRecord.speed ?? 0.0) > eps) {
+        record.speed = previousRecord.speed;
+        modified = true;
+      }
+
+      if ((record.heartRate ?? 0) <= 0 && (previousRecord.heartRate ?? 0) > 0) {
+        record.heartRate = previousRecord.heartRate;
+        modified = true;
+      }
+
+      if (modified) {
+        modifiedRecords.add(record);
+      }
+
+      previousRecord = record;
+    }
+
+    return modifiedRecords;
+  }
+
+  /// The power factor to apply for a device, falling back to 1.0 (no
+  /// adjustment) when there's no tuning on record.
+  double powerFactorFromTune(PowerTune? powerTune) => powerTune?.powerFactor ?? 1.0;
+
+  /// The calorie factor to apply for a device, falling back to 1.0 (no
+  /// adjustment) when there's no tuning on record.
+  double calorieFactorFromTune(CalorieTune? calorieTune) => calorieTune?.calorieFactor ?? 1.0;
+
+  /// Recalculates all derived per-record fields (speed/distance/calories/
+  /// elapsed/cadence/heartRate/power gap-filling) for [records] belonging to
+  /// [activity], and rolls the aggregate activity fields (distance,
+  /// calories, strides, end, elapsed, movingTime) forward from the result.
+  ///
+  /// Mutates [activity] and the entries of [records] in place. Does not
+  /// touch the database; the caller is responsible for persisting the
+  /// mutated records/activity afterwards.
+  Future<void> recalculateRecords(
+    Activity activity,
+    List<Record> records,
+    bool recalculateMore,
+  ) async {
+    if (records.isEmpty) {
+      return;
+    }
+
+    if (recalculateMore) {
+      await initPower2SpeedConstants();
+    }
+
+    var previousRecord = records.first;
+    double calories = 0.0;
+    double strides = 0.0;
+    double distance = 0.0;
+    double movingTime = 0.0;
+    for (final record in records.skip(1)) {
+      final dTMillis = record.timeStamp!.difference(previousRecord.timeStamp!).inMilliseconds;
+      final dTime = dTMillis / 1000.0;
+
+      double speed = record.speed ?? 0.0;
+      int power = record.power ?? 0;
+      int cadence = record.cadence ?? 0;
+
+      bool moving = (speed > 0.0 || power > 0 || cadence > 0);
+      if (moving) {
+        movingTime += dTMillis;
+        if ((record.cadence ?? 0) <= 0 && (previousRecord.cadence ?? 0) > 0) {
+          record.cadence = previousRecord.cadence;
+        }
+
+        if ((record.cadence ?? 0) > 0) {
+          strides += (record.cadence ?? 0) * dTMillis / (60 * 1000);
+        }
+
+        if ((record.power ?? 0) <= 0 && (previousRecord.power ?? 0) > 0) {
+          record.power = previousRecord.power;
+        }
+
+        if (record.power != null &&
+            record.power! > 0.0 &&
+            recalculateMore &&
+            activity.sport == ActivityType.ride) {
+          record.speed = velocityForPowerCardano(record.power!) * DeviceDescriptor.ms2kmh;
+        }
+
+        if ((record.speed ?? 0.0) <= eps && (previousRecord.speed ?? 0.0) > eps) {
+          record.speed = previousRecord.speed;
+        }
+      }
+
+      if ((record.heartRate ?? 0) <= 0 && (previousRecord.heartRate ?? 0) > 0) {
+        record.heartRate = previousRecord.heartRate;
+      }
+
+      record.elapsed = movingTime ~/ 1000;
+
+      // Recalculate distance
+      double dDistance = speed * DeviceDescriptor.kmh2ms * dTime;
+      distance += dDistance;
+      record.distance = distance;
+
+      // Recalculate calories
+      double dCal =
+          power *
+          dTime *
+          jToCal *
+          activity.calorieFactor *
+          DeviceDescriptor.powerCalorieFactorDefault;
+      calories += dCal;
+      record.calories = calories ~/ 1000;
+
+      previousRecord = record;
+    }
+
+    activity.distance = previousRecord.distance!;
+    activity.calories = previousRecord.calories!;
+    if (strides.toInt() > activity.strides || activity.strides > movingTime / 1000 / 60 * 180) {
+      activity.strides = strides.toInt();
+    }
+
+    if (activity.end == null || activity.end!.compareTo(previousRecord.timeStamp!) <= 0) {
+      activity.end = previousRecord.timeStamp;
+    }
+
+    activity.elapsed = activity.end!.difference(activity.start).inSeconds;
+    activity.movingTime = movingTime.toInt();
+  }
+
+  /// Fills in missing aggregate fields on [activity] from its [lastRecord],
+  /// mirroring the historical behavior of `DbUtils.finalizeActivity`.
+  ///
+  /// Mutates [activity] in place. Returns true if anything was updated.
+  bool applyFinalization(Activity activity, Record lastRecord) {
+    int updated = 0;
+    if (lastRecord.calories != null && lastRecord.calories! > 0 && activity.calories == 0) {
+      activity.calories = lastRecord.calories!;
+      updated++;
+    }
+
+    if (lastRecord.distance != null && lastRecord.distance! > 0 && activity.distance == 0) {
+      activity.distance = lastRecord.distance!;
+      updated++;
+    }
+
+    if (lastRecord.timeStamp != null && activity.end != null) {
+      activity.end = lastRecord.timeStamp!;
+      updated++;
+    }
+
+    if (lastRecord.elapsed != null && lastRecord.elapsed! > 0 && activity.elapsed == 0) {
+      activity.elapsed = lastRecord.elapsed!;
+      updated++;
+    }
+
+    if (activity.elapsed == 0 && activity.end != null) {
+      final elapsedMillis = activity.end!.difference(activity.start).inMilliseconds;
+      if (elapsedMillis >= 1000) {
+        activity.elapsed = elapsedMillis ~/ 1000;
+        updated++;
+      }
+    }
+
+    return updated > 0;
+  }
+
+  /// Computes moving time and strides from [records] and, if either is
+  /// non-trivial, applies them to [activity].
+  ///
+  /// Mutates [activity] in place. Returns true if anything was updated.
+  bool applyMovingTimeAndStrides(Activity activity, List<Record> records) {
+    if (records.isEmpty) {
+      return false;
+    }
+
+    double movingMillis = 0;
+    double strides = 0;
+    var previousRecord = records.first;
+    for (final record in records.skip(1)) {
+      final dTMillis = record.timeStamp!.difference(previousRecord.timeStamp!).inMilliseconds;
+      if (!record.isNotMoving()) {
+        movingMillis += dTMillis;
+      }
+
+      double strokeCount = record.strokeCount ?? 0.0;
+      if (strokeCount > eps) {
+        strides += strokeCount * dTMillis / (1000 * 60);
+      }
+
+      previousRecord = record;
+    }
+
+    if (movingMillis <= eps && strides <= eps) {
+      return false;
+    }
+
+    if (movingMillis > eps) {
+      activity.movingTime = movingMillis.toInt();
+    }
+
+    if (strides > eps) {
+      activity.strides = strides.toInt();
+    }
+
+    return true;
+  }
+
+  /// Shifts [activity]'s start/end by [minutes]. Mutates in place.
+  void applyTimeOffset(Activity activity, int minutes) {
+    final offset = Duration(minutes: minutes);
+    activity.start = activity.start.add(offset);
+    if (activity.end != null) {
+      activity.end = activity.end!.add(offset);
+    }
+  }
+
+  /// Shifts every record's timestamp in [records] by [minutes]. Records
+  /// without a timestamp are left untouched. Mutates in place.
+  void applyRecordTimeOffset(List<Record> records, int minutes) {
+    final offset = Duration(minutes: minutes);
+    for (final record in records) {
+      if (record.timeStamp != null) {
+        record.timeStamp = record.timeStamp!.add(offset);
+      }
+    }
+  }
+
+  /// Computes where a split at [minutesSplitPoint] minutes (measured from
+  /// the first record's timestamp) falls within [records].
+  ///
+  /// [records] must be non-empty and sorted by timestamp. Does not mutate
+  /// [records]; the caller decides how to reassign the returned
+  /// [SplitPlan.secondPartRecords] to a target activity and persist them.
+  SplitPlan computeSplitPlan(List<Record> records, int minutesSplitPoint) {
+    final splitPoint = Duration(minutes: minutesSplitPoint);
+    final watermark = records.first.timeStamp!.add(splitPoint);
+
+    DateTime? firstPartEnd;
+    DateTime? secondPartStart;
+    var inFirstPart = true;
+    var lastRecord = records.first;
+    final secondPartRecords = <Record>[];
+    for (final record in records) {
+      if (record.timeStamp != null && record.timeStamp!.compareTo(watermark) > 0) {
+        if (inFirstPart) {
+          firstPartEnd = lastRecord.timeStamp;
+          secondPartStart = record.timeStamp;
+        }
+        inFirstPart = false;
+        secondPartRecords.add(record);
+      }
+      lastRecord = record;
+    }
+
+    return SplitPlan(
+      firstPartEnd: firstPartEnd,
+      secondPartStart: secondPartStart,
+      secondPartEnd: lastRecord.timeStamp!,
+      secondPartRecords: secondPartRecords,
+    );
+  }
+}

--- a/test/track/activity_calculator_test.dart
+++ b/test/track/activity_calculator_test.dart
@@ -1,0 +1,332 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:track_my_indoor_exercise/persistence/activity.dart';
+import 'package:track_my_indoor_exercise/persistence/calorie_tune.dart';
+import 'package:track_my_indoor_exercise/persistence/power_tune.dart';
+import 'package:track_my_indoor_exercise/persistence/record.dart';
+import 'package:track_my_indoor_exercise/track/activity_calculator.dart';
+import 'package:track_my_indoor_exercise/utils/constants.dart';
+import 'package:track_my_indoor_exercise/utils/init_preferences.dart';
+
+Activity buildActivity({
+  DateTime? start,
+  DateTime? end,
+  String sport = ActivityType.ride,
+  double calorieFactor = 1.0,
+}) {
+  return Activity(
+    deviceName: "Test Dummy",
+    deviceId: "CAFEBABE",
+    hrmId: "",
+    start: start ?? DateTime(2024, 1, 1, 8, 0, 0),
+    end: end,
+    fourCC: "0000",
+    sport: sport,
+    powerFactor: 1.0,
+    calorieFactor: calorieFactor,
+    hrCalorieFactor: 1.0,
+    hrmCalorieFactor: 1.0,
+    hrBasedCalories: false,
+    timeZone: "America/Los_Angeles",
+  );
+}
+
+Record buildRecord({
+  required DateTime timeStamp,
+  int? cadence,
+  int? power,
+  double? speed,
+  int? heartRate,
+  double? strokeCount,
+}) {
+  return Record(
+    timeStamp: timeStamp,
+    cadence: cadence,
+    power: power,
+    speed: speed,
+    heartRate: heartRate,
+    strokeCount: strokeCount,
+  );
+}
+
+void main() {
+  final calculator = ActivityCalculator();
+  final base = DateTime(2024, 1, 1, 8, 0, 0);
+
+  group('bridgeDataGaps', () {
+    test('returns empty list for empty input', () {
+      expect(calculator.bridgeDataGaps([]), isEmpty);
+    });
+
+    test('returns empty list when there is nothing to bridge', () {
+      final records = [
+        buildRecord(timeStamp: base, cadence: 80, power: 100, speed: 20.0, heartRate: 120),
+        buildRecord(
+          timeStamp: base.add(const Duration(seconds: 1)),
+          cadence: 81,
+          power: 101,
+          speed: 20.1,
+          heartRate: 121,
+        ),
+      ];
+
+      final modified = calculator.bridgeDataGaps(records);
+
+      expect(modified, isEmpty);
+      expect(records[1].cadence, 81);
+      expect(records[1].power, 101);
+      expect(records[1].speed, 20.1);
+      expect(records[1].heartRate, 121);
+    });
+
+    test('forward-fills cadence, power, speed and heart rate gaps', () {
+      final gap = buildRecord(timeStamp: base.add(const Duration(seconds: 1)));
+      final records = [
+        buildRecord(timeStamp: base, cadence: 80, power: 100, speed: 20.0, heartRate: 120),
+        gap,
+      ];
+
+      final modified = calculator.bridgeDataGaps(records);
+
+      expect(modified, [gap]);
+      expect(gap.cadence, 80);
+      expect(gap.power, 100);
+      expect(gap.speed, 20.0);
+      expect(gap.heartRate, 120);
+    });
+
+    test('does not fill from a previous record that is itself zero/absent', () {
+      final gap = buildRecord(timeStamp: base.add(const Duration(seconds: 1)));
+      final records = [buildRecord(timeStamp: base), gap];
+
+      final modified = calculator.bridgeDataGaps(records);
+
+      expect(modified, isEmpty);
+      expect(gap.cadence, null);
+      expect(gap.power, null);
+      expect(gap.speed, null);
+      expect(gap.heartRate, null);
+    });
+  });
+
+  group('powerFactorFromTune / calorieFactorFromTune', () {
+    test('powerFactorFromTune defaults to 1.0 when there is no tune', () {
+      expect(calculator.powerFactorFromTune(null), 1.0);
+    });
+
+    test('powerFactorFromTune returns the tuned value', () {
+      final tune = PowerTune(mac: "AA:BB", powerFactor: 1.23, time: base);
+      expect(calculator.powerFactorFromTune(tune), 1.23);
+    });
+
+    test('calorieFactorFromTune defaults to 1.0 when there is no tune', () {
+      expect(calculator.calorieFactorFromTune(null), 1.0);
+    });
+
+    test('calorieFactorFromTune returns the tuned value', () {
+      final tune = CalorieTune(mac: "AA:BB", calorieFactor: 0.87, hrBased: false, time: base);
+      expect(calculator.calorieFactorFromTune(tune), 0.87);
+    });
+  });
+
+  group('applyTimeOffset / applyRecordTimeOffset', () {
+    test('shifts activity start and end by the given minutes', () {
+      final activity = buildActivity(start: base, end: base.add(const Duration(minutes: 30)));
+
+      calculator.applyTimeOffset(activity, 60);
+
+      expect(activity.start, base.add(const Duration(minutes: 60)));
+      expect(activity.end, base.add(const Duration(minutes: 90)));
+    });
+
+    test('leaves a null end untouched', () {
+      final activity = buildActivity(start: base);
+
+      calculator.applyTimeOffset(activity, 60);
+
+      expect(activity.start, base.add(const Duration(minutes: 60)));
+      expect(activity.end, null);
+    });
+
+    test('shifts every timestamped record and skips null timestamps', () {
+      final withTimestamp = buildRecord(timeStamp: base);
+      final records = [withTimestamp];
+
+      calculator.applyRecordTimeOffset(records, 15);
+
+      expect(withTimestamp.timeStamp, base.add(const Duration(minutes: 15)));
+    });
+  });
+
+  group('applyFinalization', () {
+    test('fills in calories, distance, elapsed and end from the last record', () {
+      final activity = buildActivity(start: base, end: base.add(const Duration(minutes: 10)));
+      final lastRecord = Record(
+        timeStamp: base.add(const Duration(minutes: 9)),
+        calories: 123,
+        distance: 4567.0,
+        elapsed: 540,
+      );
+
+      final updated = calculator.applyFinalization(activity, lastRecord);
+
+      expect(updated, true);
+      expect(activity.calories, 123);
+      expect(activity.distance, 4567.0);
+      expect(activity.elapsed, 540);
+      expect(activity.end, lastRecord.timeStamp);
+    });
+
+    test('returns false when nothing needs updating', () {
+      final activity = buildActivity(start: base);
+      activity.calories = 10;
+      activity.distance = 100.0;
+      activity.elapsed = 60;
+      final lastRecord = Record(timeStamp: base.add(const Duration(minutes: 1)));
+
+      final updated = calculator.applyFinalization(activity, lastRecord);
+
+      expect(updated, false);
+      expect(activity.calories, 10);
+      expect(activity.distance, 100.0);
+      expect(activity.elapsed, 60);
+    });
+
+    test('derives elapsed from start/end when the record has none', () {
+      final activity = buildActivity(start: base, end: base.add(const Duration(seconds: 90)));
+      final lastRecord = Record(timeStamp: base.add(const Duration(seconds: 90)));
+
+      final updated = calculator.applyFinalization(activity, lastRecord);
+
+      expect(updated, true);
+      expect(activity.elapsed, 90);
+    });
+  });
+
+  group('applyMovingTimeAndStrides', () {
+    test('returns false for an empty record list', () {
+      final activity = buildActivity(start: base);
+      expect(calculator.applyMovingTimeAndStrides(activity, []), false);
+    });
+
+    test('computes moving time and strides from stroke counts', () {
+      final activity = buildActivity(start: base);
+      final records = [
+        buildRecord(timeStamp: base, speed: 10.0, strokeCount: 0.0),
+        buildRecord(
+          timeStamp: base.add(const Duration(seconds: 30)),
+          speed: 10.0,
+          strokeCount: 5.0,
+        ),
+        buildRecord(
+          timeStamp: base.add(const Duration(seconds: 60)),
+          speed: 10.0,
+          strokeCount: 10.0,
+        ),
+      ];
+
+      final updated = calculator.applyMovingTimeAndStrides(activity, records);
+
+      expect(updated, true);
+      expect(activity.movingTime, 60000);
+      expect(activity.strides, greaterThan(0));
+    });
+  });
+
+  group('computeSplitPlan', () {
+    test('reassigns every record past the watermark to the second part', () {
+      final records = [
+        buildRecord(timeStamp: base),
+        buildRecord(timeStamp: base.add(const Duration(minutes: 5))),
+        buildRecord(timeStamp: base.add(const Duration(minutes: 11))),
+        buildRecord(timeStamp: base.add(const Duration(minutes: 15))),
+      ];
+
+      final plan = calculator.computeSplitPlan(records, 10);
+
+      expect(plan.firstPartEnd, records[1].timeStamp);
+      expect(plan.secondPartStart, records[2].timeStamp);
+      expect(plan.secondPartEnd, records[3].timeStamp);
+      expect(plan.secondPartRecords, [records[2], records[3]]);
+    });
+
+    test('leaves firstPartEnd/secondPartStart null when nothing crosses the watermark', () {
+      final records = [
+        buildRecord(timeStamp: base),
+        buildRecord(timeStamp: base.add(const Duration(minutes: 5))),
+      ];
+
+      final plan = calculator.computeSplitPlan(records, 30);
+
+      expect(plan.firstPartEnd, null);
+      expect(plan.secondPartStart, null);
+      expect(plan.secondPartEnd, records.last.timeStamp);
+      expect(plan.secondPartRecords, isEmpty);
+    });
+  });
+
+  group('recalculateRecords', () {
+    test('is a no-op for an empty record list', () async {
+      final activity = buildActivity(start: base);
+      await calculator.recalculateRecords(activity, [], false);
+      expect(activity.distance, 0.0);
+    });
+
+    test('recomputes distance and calories from speed and power', () async {
+      final activity = buildActivity(start: base, calorieFactor: 1.0);
+      final records = [
+        buildRecord(timeStamp: base, speed: 0.0, power: 0),
+        buildRecord(timeStamp: base.add(const Duration(seconds: 10)), speed: 36.0, power: 200),
+      ];
+
+      await calculator.recalculateRecords(activity, records, false);
+
+      // speed is 36 km/h = 10 m/s, over 10s => 100m
+      expect(records[1].distance, closeTo(100.0, 1e-9));
+      expect(activity.distance, closeTo(100.0, 1e-9));
+      expect(activity.movingTime, 10000);
+      expect(activity.elapsed, activity.end!.difference(activity.start).inSeconds);
+    });
+
+    test('always forward-fills heart rate gaps, regardless of movement', () async {
+      final activity = buildActivity(start: base);
+      final records = [
+        buildRecord(timeStamp: base, heartRate: 130),
+        buildRecord(timeStamp: base.add(const Duration(seconds: 5))),
+      ];
+
+      await calculator.recalculateRecords(activity, records, false);
+
+      expect(records[1].heartRate, 130);
+    });
+
+    test('forward-fills cadence/power gaps only while the record is moving', () async {
+      final activity = buildActivity(start: base);
+      // The second record still reports non-zero cadence itself, so it
+      // counts as "moving" and is eligible to inherit the missing power
+      // from the previous record.
+      final records = [
+        buildRecord(timeStamp: base, speed: 18.0, power: 150, cadence: 80),
+        buildRecord(timeStamp: base.add(const Duration(seconds: 5)), cadence: 80),
+      ];
+
+      await calculator.recalculateRecords(activity, records, false);
+
+      expect(records[1].power, 150);
+    });
+
+    test('uses the power-to-speed conversion for rides when recalculateMore is set', () async {
+      await initPrefServiceForTest();
+      final activity = buildActivity(start: base, sport: ActivityType.ride);
+      final records = [
+        buildRecord(timeStamp: base, speed: 0.0, power: 0),
+        buildRecord(timeStamp: base.add(const Duration(seconds: 5)), power: 150),
+      ];
+
+      await calculator.recalculateRecords(activity, records, true);
+
+      // Speed should have been derived from power rather than left null/unset.
+      expect(records[1].speed, isNotNull);
+      expect(records[1].speed, greaterThan(0.0));
+    });
+  });
+}


### PR DESCRIPTION
Adds lib/track/activity_calculator.dart (ActivityCalculator) holding the pure, DB-free per-record/per-activity calculations that previously lived inline in DbUtils: gap-bridging, power/calorie factor fallback logic, the per-record recalculation math driving recalculateCumulative, activity finalization aggregates, time-offset math, and split-point computation for splitActivity. DbUtils now only orchestrates Isar reads/writes around calls into ActivityCalculator, and no longer needs PowerSpeedMixin directly.

Target creation/lookup in splitActivity stays in DbUtils since deciding whether to reuse or create the target Activity is inherently a DB-existence check that doesn't separate cleanly from the write path.

Adds test/track/activity_calculator_test.dart with focused unit tests for every extracted method (none of these calculations had direct unit tests before, since they were only reachable through DbUtils and Isar).

Also documents the app's existing state-management convention (GetX as a service locator only, setState for rebuilds) in README's Contribution Rules, per issue #10, to steer future code away from introducing a third pattern.